### PR TITLE
Use AWS cli export credential as the first provider in the chain

### DIFF
--- a/src/cmd/cli/main.go
+++ b/src/cmd/cli/main.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/smithy-go"
 	"github.com/bufbuild/connect-go"
 	"github.com/spf13/cobra"
 	"golang.org/x/mod/semver"
@@ -880,7 +881,13 @@ func main() {
 
 		code := connect.CodeOf(err)
 		if code == connect.CodeUnauthenticated {
-			printDefangHint("Please use the following command to log in:", "login")
+			// All AWS errors are wrapped in OperationError
+			var oe *smithy.OperationError
+			if errors.As(err, &oe) {
+				fmt.Println("Could not authenticate to the AWS service. Please check your aws credentials and try again.")
+			} else {
+				printDefangHint("Please use the following command to log in:", "login")
+			}
 		}
 		if code == connect.CodeFailedPrecondition && (strings.Contains(err.Error(), "EULA") || strings.Contains(err.Error(), "terms")) {
 			printDefangHint("Please use the following command to agree to the Defang terms of service:", "terms --agree-tos")

--- a/src/pkg/cli/connect.go
+++ b/src/pkg/cli/connect.go
@@ -38,7 +38,7 @@ func Connect(cluster string, provider client.Provider) (client.Client, types.Ten
 	Info(" * Connecting to", host)
 	defangClient := client.NewGrpcClient(host, accessToken)
 
-	awsInEnv := os.Getenv("AWS_PROFILE") != "" || os.Getenv("AWS_REGION") != "" || os.Getenv("AWS_ACCESS_KEY_ID") != "" || os.Getenv("AWS_SECRET_ACCESS_KEY") != ""
+	awsInEnv := os.Getenv("AWS_PROFILE") != "" || os.Getenv("AWS_ACCESS_KEY_ID") != "" || os.Getenv("AWS_SECRET_ACCESS_KEY") != ""
 	if provider == client.ProviderAWS || (provider == client.ProviderAuto && awsInEnv) {
 		Info(" * Using AWS provider")
 		if !awsInEnv {


### PR DESCRIPTION
This would make sure defang cli would behave exactly the same in how to look up the credentials as the aws cli, since aws cli have a different behavior for sso logged in users, which does not save the credentials to the standard location the go sdk check, and if there is a wrong/expired credential saved with the same profile name, the aws cli would still succeed but defang cli would fail which could be very confusing for customers.

Also updated the hint for if the aws credentials expired. 

Do not defaults to aws provider when there is only AWS_REGION environment variable is detected.