### PR TITLE
tail: only show logs from my cd

### DIFF
--- a/src/pkg/aws/ecs/logs.go
+++ b/src/pkg/aws/ecs/logs.go
@@ -134,7 +134,7 @@ func TailLogGroups(ctx context.Context, logGroups ...LogGroupInput) (EventStream
 
 // LogGroupInput is like cloudwatchlogs.StartLiveTailInput but with only one loggroup and one logstream prefix.
 type LogGroupInput struct {
-	LogGroup              string
+	LogGroupARN           string
 	LogStreamNames        []string
 	LogStreamNamePrefix   string
 	LogEventFilterPattern string
@@ -150,7 +150,7 @@ func TailLogGroup(ctx context.Context, input LogGroupInput) (EventStream, error)
 		prefixes = []string{input.LogStreamNamePrefix}
 	}
 	return startTail(ctx, &cloudwatchlogs.StartLiveTailInput{
-		LogGroupIdentifiers:   []string{getLogGroupIdentifier(input.LogGroup)},
+		LogGroupIdentifiers:   []string{getLogGroupIdentifier(input.LogGroupARN)},
 		LogStreamNames:        input.LogStreamNames,
 		LogStreamNamePrefixes: prefixes,
 		LogEventFilterPattern: pattern,
@@ -158,13 +158,13 @@ func TailLogGroup(ctx context.Context, input LogGroupInput) (EventStream, error)
 }
 
 func Query(ctx context.Context, lgi LogGroupInput, start time.Time, end time.Time) ([]LogEvent, error) {
-	region := region.FromArn(lgi.LogGroup) // FIXME: ensure it's a log group ARN
+	region := region.FromArn(lgi.LogGroupARN)
 	cfg, err := aws.LoadDefaultConfig(ctx, region)
 	if err != nil {
 		return nil, err
 	}
 
-	logGroupIdentifier := getLogGroupIdentifier(lgi.LogGroup)
+	logGroupIdentifier := getLogGroupIdentifier(lgi.LogGroupARN)
 	var prefix *string
 	if lgi.LogStreamNamePrefix != "" {
 		prefix = &lgi.LogStreamNamePrefix

--- a/src/pkg/aws/ecs/logs.go
+++ b/src/pkg/aws/ecs/logs.go
@@ -62,7 +62,7 @@ func getLogGroupIdentifier(arnOrId string) string {
 	return strings.TrimSuffix(arnOrId, ":*")
 }
 
-func TailLogGroups(ctx context.Context, logGroups ...string) (EventStream, error) {
+func TailLogGroups(ctx context.Context, logGroups ...LogGroupInput) (EventStream, error) {
 	var cs = collectionStream{
 		ch:    make(chan types.StartLiveTailResponseStream),
 		errCh: make(chan error),
@@ -70,7 +70,7 @@ func TailLogGroups(ctx context.Context, logGroups ...string) (EventStream, error
 	}
 
 	var streams []EventStream
-	var pendingGroups []string
+	var pendingGroups []LogGroupInput
 
 	for _, lg := range logGroups {
 		es, err := TailLogGroup(ctx, lg)
@@ -88,9 +88,9 @@ func TailLogGroups(ctx context.Context, logGroups ...string) (EventStream, error
 
 	// Start goroutines to wait for the log group to be created for the resource not found log groups
 	since := time.Now()
-	for _, lg := range pendingGroups {
+	for _, lgi := range pendingGroups {
 		cs.wg.Add(1)
-		go func(ctx context.Context, lgID string) {
+		go func(ctx context.Context, lgi LogGroupInput) {
 			defer cs.wg.Done()
 			ticker := time.NewTicker(time.Second)
 			defer ticker.Stop()
@@ -100,10 +100,10 @@ func TailLogGroups(ctx context.Context, logGroups ...string) (EventStream, error
 				case <-cs.done:
 					return
 				case <-ticker.C:
-					es, err := TailLogGroup(ctx, lgID)
+					es, err := TailLogGroup(ctx, lgi)
 					if err == nil {
 						// Query the logs between the start time and now
-						if events, err := Query(ctx, lgID, since, time.Now()); err == nil {
+						if events, err := Query(ctx, lgi, since, time.Now()); err == nil {
 							// println("found logs:", len(events))
 							cs.ch <- &types.StartLiveTailResponseStreamMemberSessionUpdate{
 								Value: types.LiveTailSessionUpdate{SessionResults: events},
@@ -121,7 +121,7 @@ func TailLogGroups(ctx context.Context, logGroups ...string) (EventStream, error
 					}
 				}
 			}
-		}(ctx, lg)
+		}(ctx, lgi)
 	}
 
 	// Only add and start watching the streams if there were no errors, prevent lingering goroutines
@@ -132,28 +132,50 @@ func TailLogGroups(ctx context.Context, logGroups ...string) (EventStream, error
 	return &cs, nil
 }
 
-func TailLogGroup(ctx context.Context, logGroupArn string, logStreams ...string) (EventStream, error) {
+// LogGroupInput is like cloudwatchlogs.StartLiveTailInput but with only one loggroup and one logstream prefix.
+type LogGroupInput struct {
+	LogGroup              string
+	LogStreamNames        []string
+	LogStreamNamePrefix   string
+	LogEventFilterPattern string
+}
+
+func TailLogGroup(ctx context.Context, input LogGroupInput) (EventStream, error) {
+	var pattern *string
+	if input.LogEventFilterPattern != "" {
+		pattern = &input.LogEventFilterPattern
+	}
+	var prefixes []string
+	if input.LogStreamNamePrefix != "" {
+		prefixes = []string{input.LogStreamNamePrefix}
+	}
 	return startTail(ctx, &cloudwatchlogs.StartLiveTailInput{
-		LogGroupIdentifiers: []string{getLogGroupIdentifier(logGroupArn)},
-		LogStreamNames:      logStreams,
+		LogGroupIdentifiers:   []string{getLogGroupIdentifier(input.LogGroup)},
+		LogStreamNames:        input.LogStreamNames,
+		LogStreamNamePrefixes: prefixes,
+		LogEventFilterPattern: pattern,
 	})
 }
 
-func Query(ctx context.Context, logGroupArn string, start time.Time, end time.Time) ([]LogEvent, error) {
-	region := region.FromArn(logGroupArn)
+func Query(ctx context.Context, lgi LogGroupInput, start time.Time, end time.Time) ([]LogEvent, error) {
+	region := region.FromArn(lgi.LogGroup) // FIXME: ensure it's a log group ARN
 	cfg, err := aws.LoadDefaultConfig(ctx, region)
 	if err != nil {
 		return nil, err
 	}
 
-	logGroupIdentifier := getLogGroupIdentifier(logGroupArn)
+	logGroupIdentifier := getLogGroupIdentifier(lgi.LogGroup)
+	var prefix *string
+	if lgi.LogStreamNamePrefix != "" {
+		prefix = &lgi.LogStreamNamePrefix
+	}
 	cw := cloudwatchlogs.NewFromConfig(cfg)
 	fleo, err := cw.FilterLogEvents(ctx, &cloudwatchlogs.FilterLogEventsInput{
-		StartTime:          ptr.Int64(start.UnixMilli()),
-		EndTime:            ptr.Int64(end.UnixMilli()),
-		LogGroupIdentifier: &logGroupIdentifier,
-		// LogStreamNamePrefix:,
-		// LogStreamNames: ,
+		StartTime:           ptr.Int64(start.UnixMilli()),
+		EndTime:             ptr.Int64(end.UnixMilli()),
+		LogGroupIdentifier:  &logGroupIdentifier,
+		LogStreamNamePrefix: prefix,
+		LogStreamNames:      lgi.LogStreamNames,
 	})
 	if err != nil {
 		return nil, err

--- a/src/pkg/aws/ecs/tail.go
+++ b/src/pkg/aws/ecs/tail.go
@@ -55,7 +55,7 @@ func (a *AwsEcs) TailTaskID(ctx context.Context, taskID string) (EventStream, er
 	if taskID == "" {
 		return nil, errors.New("taskID is empty")
 	}
-	lgi := LogGroupInput{LogGroup: a.LogGroupARN, LogStreamNames: []string{GetLogStreamForTaskID(taskID)}}
+	lgi := LogGroupInput{LogGroupARN: a.LogGroupARN, LogStreamNames: []string{GetLogStreamForTaskID(taskID)}}
 	for {
 		stream, err := TailLogGroup(ctx, lgi)
 		if err != nil {

--- a/src/pkg/aws/ecs/tail.go
+++ b/src/pkg/aws/ecs/tail.go
@@ -55,9 +55,9 @@ func (a *AwsEcs) TailTaskID(ctx context.Context, taskID string) (EventStream, er
 	if taskID == "" {
 		return nil, errors.New("taskID is empty")
 	}
-	logStreamName := getLogStreamForTaskID(taskID)
+	lgi := LogGroupInput{LogGroup: a.LogGroupARN, LogStreamNames: []string{GetLogStreamForTaskID(taskID)}}
 	for {
-		stream, err := TailLogGroup(ctx, a.LogGroupARN, logStreamName)
+		stream, err := TailLogGroup(ctx, lgi)
 		if err != nil {
 			var resourceNotFound *types.ResourceNotFoundException
 			if !errors.As(err, &resourceNotFound) {
@@ -77,7 +77,7 @@ func (a *AwsEcs) TailTaskID(ctx context.Context, taskID string) (EventStream, er
 	}
 }
 
-func getLogStreamForTaskID(taskID string) string {
+func GetLogStreamForTaskID(taskID string) string {
 	return path.Join(AwsLogsStreamPrefix, ContainerName, taskID) // per "awslogs" driver
 }
 

--- a/src/pkg/aws/ecs/tail_test.go
+++ b/src/pkg/aws/ecs/tail_test.go
@@ -7,7 +7,7 @@ import (
 func TestGetLogStreamForTaskID(t *testing.T) {
 	expectedLogStream := "crun/main/12345678123412341234123456789012"
 
-	logStream := getLogStreamForTaskID("12345678123412341234123456789012")
+	logStream := GetLogStreamForTaskID("12345678123412341234123456789012")
 
 	if logStream != expectedLogStream {
 		t.Errorf("Expected log stream %q, but got %q", expectedLogStream, logStream)

--- a/src/pkg/cli/client/byoc.go
+++ b/src/pkg/cli/client/byoc.go
@@ -219,7 +219,7 @@ func (b *byocAws) Deploy(ctx context.Context, req *v1.DeployRequest) (*v1.Deploy
 	}, warnings
 }
 
-func (b byocAws) FindZone(ctx context.Context, domain, role string) (string, error) {
+func (b byocAws) findZone(ctx context.Context, domain, role string) (string, error) {
 	cfg, err := b.driver.LoadConfig(ctx)
 	if err != nil {
 		return "", annotateAwsError(err)
@@ -555,22 +555,24 @@ func (bs *byocServerStream) Receive() bool {
 		parseFirelensRecords := false
 		// Get the Etag/Host/Service from the first event (should be the same for all events in this batch)
 		event := events[0]
-		if strings.Contains(*event.LogGroupIdentifier, ":"+cdTaskPrefix) {
-			// These events are from the CD task; detect stdout/stderr
-			bs.response.Etag = bs.etag // FIXME: this would show all deployments, not just the one we're interested in
-			bs.response.Host = "pulumi"
-			bs.response.Service = "cd"
-		} else if parts := strings.Split(*event.LogStreamName, "/"); len(parts) == 3 {
-			// These events are from a awslogs service task: tenant/service_etag/taskID
-			bs.response.Host = parts[2] // TODO: figure out hostname/IP
-			parts = strings.Split(parts[1], "_")
-			if len(parts) != 2 || !pkg.IsValidRandomID(parts[1]) {
-				// ignore sidecar logs (like route53-sidecar or fluentbit)
-				return true
+		if parts := strings.Split(*event.LogStreamName, "/"); len(parts) == 3 {
+			if strings.Contains(*event.LogGroupIdentifier, ":"+cdTaskPrefix) {
+				// These events are from the CD task: "crun/main/taskID" stream; we should detect stdout/stderr
+				bs.response.Etag = bs.etag // pass the etag filter below, but we already filtered the tail by taskID
+				bs.response.Host = "pulumi"
+				bs.response.Service = "cd"
+			} else {
+				// These events are from an awslogs service task: "tenant/service_etag/taskID" stream
+				bs.response.Host = parts[2] // TODO: figure out actual hostname/IP
+				parts = strings.Split(parts[1], "_")
+				if len(parts) != 2 || !pkg.IsValidRandomID(parts[1]) {
+					// skip, ignore sidecar logs (like route53-sidecar or fluentbit)
+					return true
+				}
+				service, etag := parts[0], parts[1]
+				bs.response.Etag = etag
+				bs.response.Service = service
 			}
-			service, etag := parts[0], parts[1]
-			bs.response.Etag = etag
-			bs.response.Service = service
 		} else if strings.Contains(*event.LogStreamName, "-firelens-") {
 			// These events are from the Firelens sidecar; try to parse the JSON
 			if err := json.Unmarshal([]byte(*event.Message), &record); err == nil {
@@ -635,19 +637,24 @@ func (b *byocAws) Tail(ctx context.Context, req *v1.TailRequest) (ServerStream[v
 	//  * No Etag, service:		tail all tasks/services with that service name
 	//  * Etag, service:		tail that task/service
 	var err error
-	var cdTaskArn awsecs.TaskArn
+	var taskArn awsecs.TaskArn
 	var eventStream awsecs.EventStream
 	if etag != "" && !pkg.IsValidRandomID(etag) {
-		// Assume "etag" is the CD task ID
+		// Assume "etag" is a task ID
 		eventStream, err = b.driver.TailTaskID(ctx, etag)
-		cdTaskArn, _ = b.driver.GetTaskArn(etag)
+		taskArn, _ = b.driver.GetTaskArn(etag)
 		etag = "" // no need to filter by etag
 	} else {
 		// Tail CD, kaniko, and all services
-		kanikoLogGroup := b.driver.MakeARN("logs", "log-group:"+b.stackDir("kaniko"))     // must match logic in ecs/common.ts
-		servicesLogGroup := b.driver.MakeARN("logs", "log-group:"+b.stackDir("logGroup")) // must match logic in ecs/common.ts
-		eventStream, err = awsecs.TailLogGroups(ctx, b.driver.LogGroupARN, kanikoLogGroup, servicesLogGroup)
-		cdTaskArn = b.cdTasks[etag]
+		kanikoTail := awsecs.LogGroupInput{LogGroup: b.driver.MakeARN("logs", "log-group:"+b.stackDir("kaniko"))}     // must match logic in ecs/common.ts
+		servicesTail := awsecs.LogGroupInput{LogGroup: b.driver.MakeARN("logs", "log-group:"+b.stackDir("logGroup"))} // must match logic in ecs/common.ts
+		cdTail := awsecs.LogGroupInput{LogGroup: b.driver.LogGroupARN}
+		taskArn = b.cdTasks[etag]
+		if taskArn != nil {
+			// Only tail the logstreams for the CD task
+			cdTail.LogStreamNames = []string{awsecs.GetLogStreamForTaskID(awsecs.GetTaskID(taskArn))}
+		}
+		eventStream, err = awsecs.TailLogGroups(ctx, cdTail, kanikoTail, servicesTail)
 	}
 	if err != nil {
 		return nil, annotateAwsError(err)
@@ -664,10 +671,10 @@ func (b *byocAws) Tail(ctx context.Context, req *v1.TailRequest) (ServerStream[v
 
 	taskch := make(chan error)
 	var cancel func()
-	if cdTaskArn != nil {
+	if taskArn != nil {
 		ctx, cancel = context.WithCancel(ctx)
 		go func() {
-			taskch <- awsecs.WaitForTask(ctx, cdTaskArn, 3*time.Second)
+			taskch <- awsecs.WaitForTask(ctx, taskArn, 3*time.Second)
 		}()
 	}
 	return &byocServerStream{
@@ -687,7 +694,7 @@ func (b byocAws) update(ctx context.Context, service *v1.Service) (*v1.ServiceIn
 	}
 
 	// Check to make sure all required secrets are present in the secrets store
-	missing, err := b.checkForMissingSecrets(ctx, service.Secrets, b.tenantID)
+	missing, err := b.checkForMissingSecrets(ctx, service.Secrets)
 	if err != nil {
 		return nil, err
 	}
@@ -728,7 +735,7 @@ func (b byocAws) update(ctx context.Context, service *v1.Service) (*v1.ServiceIn
 			warning = WarningError(fmt.Sprintf("error looking up CNAME %q: %v", service.Domainname, err))
 		}
 		if strings.TrimSuffix(cname, ".") != si.PublicFqdn {
-			zoneId, err := b.FindZone(ctx, service.Domainname, service.DnsRole)
+			zoneId, err := b.findZone(ctx, service.Domainname, service.DnsRole)
 			if err != nil {
 				return nil, err
 			}
@@ -749,7 +756,7 @@ func (b byocAws) update(ctx context.Context, service *v1.Service) (*v1.ServiceIn
 }
 
 // This function was copied from Fabric controller and slightly modified to work with BYOC
-func (b byocAws) checkForMissingSecrets(ctx context.Context, secrets []*v1.Secret, tenantId string) (*v1.Secret, error) {
+func (b byocAws) checkForMissingSecrets(ctx context.Context, secrets []*v1.Secret) (*v1.Secret, error) {
 	prefix := b.getSecretID("")
 	sorted, err := b.driver.ListSecretsByPrefix(ctx, prefix)
 	if err != nil {

--- a/src/pkg/cli/client/byoc.go
+++ b/src/pkg/cli/client/byoc.go
@@ -646,9 +646,9 @@ func (b *byocAws) Tail(ctx context.Context, req *v1.TailRequest) (ServerStream[v
 		etag = "" // no need to filter by etag
 	} else {
 		// Tail CD, kaniko, and all services
-		kanikoTail := awsecs.LogGroupInput{LogGroup: b.driver.MakeARN("logs", "log-group:"+b.stackDir("kaniko"))}     // must match logic in ecs/common.ts
-		servicesTail := awsecs.LogGroupInput{LogGroup: b.driver.MakeARN("logs", "log-group:"+b.stackDir("logGroup"))} // must match logic in ecs/common.ts
-		cdTail := awsecs.LogGroupInput{LogGroup: b.driver.LogGroupARN}
+		kanikoTail := awsecs.LogGroupInput{LogGroupARN: b.driver.MakeARN("logs", "log-group:"+b.stackDir("kaniko"))}     // must match logic in ecs/common.ts
+		servicesTail := awsecs.LogGroupInput{LogGroupARN: b.driver.MakeARN("logs", "log-group:"+b.stackDir("logGroup"))} // must match logic in ecs/common.ts
+		cdTail := awsecs.LogGroupInput{LogGroupARN: b.driver.LogGroupARN}
 		taskArn = b.cdTasks[etag]
 		if taskArn != nil {
 			// Only tail the logstreams for the CD task


### PR DESCRIPTION
Fixes #129 

Fixed by using the ability of cloudwatch API to tail not just a loggroup but a specific logstream: we know the task ID (we got it from the RunTask API) so we only tail that logstream.