### PR TITLE
cli: fix panic/segfault in dry-run compose

### DIFF
--- a/src/pkg/cli/bootstrap.go
+++ b/src/pkg/cli/bootstrap.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/defang-io/defang/src/pkg/cli/client"
@@ -10,7 +9,7 @@ import (
 
 func BootstrapCommand(ctx context.Context, client client.Client, command string) error {
 	if DoDryRun {
-		return errors.New("dry run")
+		return ErrDryRun
 	}
 	etag, err := client.BootstrapCommand(ctx, command)
 	if err != nil || etag == "" {

--- a/src/pkg/cli/common.go
+++ b/src/pkg/cli/common.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"google.golang.org/protobuf/encoding/protojson"
@@ -14,6 +15,8 @@ var (
 	DoDebug     = false
 	DoDryRun    = false
 	HadWarnings = false
+
+	ErrDryRun = errors.New("dry run")
 )
 
 func MarshalPretty(root string, data proto.Message) ([]byte, error) {

--- a/src/pkg/cli/compose.go
+++ b/src/pkg/cli/compose.go
@@ -248,7 +248,7 @@ func uploadTarball(ctx context.Context, client client.Client, body io.Reader, di
 	}
 
 	if DoDryRun {
-		return "", errors.New("dry run")
+		return "", ErrDryRun
 	}
 
 	// Do an HTTP PUT to the generated URL

--- a/src/pkg/cli/composeStart.go
+++ b/src/pkg/cli/composeStart.go
@@ -402,7 +402,7 @@ func ComposeStart(ctx context.Context, c client.Client, filePath string, tenantI
 		for _, service := range services {
 			PrintObject(service.Name, service)
 		}
-		return nil, nil
+		return nil, ErrDryRun
 	}
 
 	for _, service := range services {

--- a/src/pkg/cli/delete.go
+++ b/src/pkg/cli/delete.go
@@ -11,7 +11,7 @@ func Delete(ctx context.Context, client client.Client, names ...string) (string,
 	Debug(" - Deleting service", names)
 
 	if DoDryRun {
-		return "", nil
+		return "", ErrDryRun
 	}
 
 	resp, err := client.Delete(ctx, &v1.DeleteRequest{Names: names})

--- a/src/pkg/cli/generate.go
+++ b/src/pkg/cli/generate.go
@@ -12,7 +12,7 @@ import (
 func Generate(ctx context.Context, client client.Client, language string, description string) ([]string, error) {
 	if DoDryRun {
 		Warn(" ! Dry run, not generating files")
-		return nil, nil
+		return nil, ErrDryRun
 	}
 
 	response, err := client.GenerateFiles(ctx, &v1.GenerateFilesRequest{

--- a/src/pkg/cli/restart.go
+++ b/src/pkg/cli/restart.go
@@ -9,9 +9,6 @@ import (
 
 func Restart(ctx context.Context, client client.Client, names ...string) ([]*v1.ServiceInfo, error) {
 	Debug(" - Restarting service", names)
-	if DoDryRun {
-		return nil, nil
-	}
 
 	// For now, we'll just get the service info and pass it to deploy as-is.
 	services := make([]*v1.Service, 0, len(names))
@@ -22,6 +19,10 @@ func Restart(ctx context.Context, client client.Client, names ...string) ([]*v1.
 			continue
 		}
 		services = append(services, serviceInfo.Service)
+	}
+
+	if DoDryRun {
+		return nil, ErrDryRun
 	}
 
 	resp, err := client.Deploy(ctx, &v1.DeployRequest{Services: services})

--- a/src/pkg/cli/secretsDelete.go
+++ b/src/pkg/cli/secretsDelete.go
@@ -11,7 +11,7 @@ func SecretsDelete(ctx context.Context, client client.Client, name string) error
 	Debug(" - Deleting secret", name)
 
 	if DoDryRun {
-		return nil
+		return ErrDryRun
 	}
 
 	// FIXME: create dedicated DeleteSecret method in client proto

--- a/src/pkg/cli/secretsSet.go
+++ b/src/pkg/cli/secretsSet.go
@@ -16,7 +16,7 @@ func SecretsSet(ctx context.Context, client client.Client, name string, value st
 	}
 
 	if DoDryRun {
-		return nil
+		return ErrDryRun
 	}
 
 	err := client.PutSecret(ctx, &v1.SecretValue{Name: name, Value: value})

--- a/src/pkg/cli/sendMsg.go
+++ b/src/pkg/cli/sendMsg.go
@@ -23,7 +23,7 @@ func SendMsg(ctx context.Context, client client.Client, subject, _type, id strin
 	Debug(" - Sending message to", subject, "with type", _type, "and id", id)
 
 	if DoDryRun {
-		return nil
+		return ErrDryRun
 	}
 
 	err := client.Publish(ctx, &v1.PublishRequest{Event: &v1.Event{

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -84,10 +84,6 @@ func (cerr *CancelError) Unwrap() error {
 }
 
 func Tail(ctx context.Context, client client.Client, service, etag string, since time.Time, raw bool) error {
-	if DoDryRun {
-		return nil
-	}
-
 	if service != "" {
 		service = NormalizeServiceName(service)
 		// Show a warning if the service doesn't exist (yet);; TODO: could do fuzzy matching and suggest alternatives
@@ -101,6 +97,10 @@ func Tail(ctx context.Context, client client.Client, service, etag string, since
 				Warn(" !", err)
 			}
 		}
+	}
+
+	if DoDryRun {
+		return ErrDryRun
 	}
 
 	tailClient, err := client.Tail(ctx, &v1.TailRequest{Service: service, Etag: etag, Since: timestamppb.New(since)})

--- a/src/pkg/cli/token.go
+++ b/src/pkg/cli/token.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -15,7 +14,7 @@ import (
 
 func Token(ctx context.Context, client client.Client, clientId string, tenant types.TenantID, dur time.Duration, scope scope.Scope) error {
 	if DoDryRun {
-		return errors.New("dry-run")
+		return ErrDryRun
 	}
 
 	code, err := github.StartAuthCodeFlow(ctx, clientId)


### PR DESCRIPTION
Reported by Don: happens because w/ `--dry-run` we don't return an error, but also don't return a project, but we'd still try to print the endpoints. Fixed by returning a specific dry-run error.