### PR TITLE
Crun sidecar support

### DIFF
--- a/src/pkg/aws/ecs/cfn/setup.go
+++ b/src/pkg/aws/ecs/cfn/setup.go
@@ -49,6 +49,7 @@ func (a *AwsEcs) newClient(ctx context.Context) (*cloudformation.Client, error) 
 	return cloudformation.NewFromConfig(cfg), nil
 }
 
+// update1s is a functional option for cloudformation.StackUpdateCompleteWaiter that sets the MinDelay to 1
 func update1s(o *cloudformation.StackUpdateCompleteWaiterOptions) {
 	o.MinDelay = 1
 }
@@ -84,6 +85,7 @@ func (a *AwsEcs) updateStackAndWait(ctx context.Context, templateBody string) er
 	return a.fillWithOutputs(ctx, o)
 }
 
+// create1s is a functional option for cloudformation.StackCreateCompleteWaiter that sets the MinDelay to 1
 func create1s(o *cloudformation.StackCreateCompleteWaiterOptions) {
 	o.MinDelay = 1
 }
@@ -118,8 +120,8 @@ func (a *AwsEcs) createStackAndWait(ctx context.Context, templateBody string) er
 	return a.fillWithOutputs(ctx, dso)
 }
 
-func (a *AwsEcs) SetUp(ctx context.Context, tasks []types.Task) error {
-	template, err := createTemplate(a.stackName, tasks, a.Spot).YAML()
+func (a *AwsEcs) SetUp(ctx context.Context, containers []types.Container) error {
+	template, err := createTemplate(a.stackName, containers, a.Spot).YAML()
 	if err != nil {
 		return err
 	}
@@ -227,7 +229,12 @@ func (a *AwsEcs) TearDown(ctx context.Context) error {
 	}
 
 	fmt.Println("Waiting for stack", a.stackName, "to be deleted...") // TODO: verbose only
-	return cloudformation.NewStackDeleteCompleteWaiter(cfn).Wait(ctx, &cloudformation.DescribeStacksInput{
+	return cloudformation.NewStackDeleteCompleteWaiter(cfn, delete1s).Wait(ctx, &cloudformation.DescribeStacksInput{
 		StackName: ptr.String(a.stackName),
 	}, stackTimeout)
+}
+
+// delete1s is a functional option for cloudformation.StackDeleteCompleteWaiter that sets the MinDelay to 1
+func delete1s(o *cloudformation.StackDeleteCompleteWaiterOptions) {
+	o.MinDelay = 1
 }

--- a/src/pkg/aws/ecs/cfn/setup.go
+++ b/src/pkg/aws/ecs/cfn/setup.go
@@ -82,7 +82,7 @@ func (a *AwsEcs) updateStackAndWait(ctx context.Context, templateBody string) er
 	if err != nil {
 		return err
 	}
-	return a.fillWithOutputs(ctx, o)
+	return a.fillWithOutputs(o)
 }
 
 // create1s is a functional option for cloudformation.StackCreateCompleteWaiter that sets the MinDelay to 1
@@ -117,7 +117,7 @@ func (a *AwsEcs) createStackAndWait(ctx context.Context, templateBody string) er
 	if err != nil {
 		return err
 	}
-	return a.fillWithOutputs(ctx, dso)
+	return a.fillWithOutputs(dso)
 }
 
 func (a *AwsEcs) SetUp(ctx context.Context, containers []types.Container) error {
@@ -153,10 +153,10 @@ func (a *AwsEcs) fillOutputs(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return a.fillWithOutputs(ctx, dso)
+	return a.fillWithOutputs(dso)
 }
 
-func (a *AwsEcs) fillWithOutputs(ctx context.Context, dso *cloudformation.DescribeStacksOutput) error {
+func (a *AwsEcs) fillWithOutputs(dso *cloudformation.DescribeStacksOutput) error {
 	for _, stack := range dso.Stacks {
 		for _, output := range stack.Outputs {
 			switch *output.OutputKey {

--- a/src/pkg/aws/ecs/cfn/setup.go
+++ b/src/pkg/aws/ecs/cfn/setup.go
@@ -36,7 +36,6 @@ func New(stack string, region region.Region) *AwsEcs {
 		AwsEcs: ecs.AwsEcs{
 			Aws:  common.Aws{Region: region},
 			Spot: true,
-			VCpu: 1.0,
 		},
 	}
 }
@@ -119,9 +118,8 @@ func (a *AwsEcs) createStackAndWait(ctx context.Context, templateBody string) er
 	return a.fillWithOutputs(ctx, dso)
 }
 
-func (a *AwsEcs) SetUp(ctx context.Context, image string, memory uint64, platform string) error {
-	arch := ecs.PlatformToArch(platform)
-	template, err := createTemplate(a.stackName, image, float64(memory)/1024/1024, a.VCpu, a.Spot, arch).YAML()
+func (a *AwsEcs) SetUp(ctx context.Context, tasks []types.Task) error {
+	template, err := createTemplate(a.stackName, tasks, a.Spot).YAML()
 	if err != nil {
 		return err
 	}

--- a/src/pkg/aws/ecs/cfn/template.go
+++ b/src/pkg/aws/ecs/cfn/template.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"github.com/awslabs/goformation/v7/cloudformation/ecs"
 	"github.com/awslabs/goformation/v7/cloudformation/iam"
 	"github.com/awslabs/goformation/v7/cloudformation/logs"
+	"github.com/awslabs/goformation/v7/cloudformation/policies"
 	"github.com/awslabs/goformation/v7/cloudformation/s3"
 	"github.com/awslabs/goformation/v7/cloudformation/secretsmanager"
 	"github.com/awslabs/goformation/v7/cloudformation/tags"
@@ -31,6 +33,7 @@ const (
 var (
 	dockerHubUsername    = os.Getenv("DOCKERHUB_USERNAME") // TODO: support DOCKER_AUTH_CONFIG
 	dockerHubAccessToken = os.Getenv("DOCKERHUB_ACCESS_TOKEN")
+	retainBucket         = true // set to false in unit tests
 )
 
 func getCacheRepoPrefix(prefix, suffix string) string {
@@ -43,7 +46,7 @@ func getCacheRepoPrefix(prefix, suffix string) string {
 	return repo
 }
 
-func createTemplate(stack string, tasks []types.Task, spot bool) *cloudformation.Template {
+func createTemplate(stack string, containers []types.Container, spot bool) *cloudformation.Template {
 	prefix := stack + "-"
 
 	defaultTags := []tags.Tag{
@@ -55,12 +58,16 @@ func createTemplate(stack string, tasks []types.Task, spot bool) *cloudformation
 
 	template := cloudformation.NewTemplate()
 
-	// 1. bucket (for state)
+	// 1. bucket (for deployment state)
 	const _bucket = "Bucket"
+	var bucketDeletionPolicy policies.DeletionPolicy
+	if retainBucket {
+		bucketDeletionPolicy = "RetainExceptOnCreate"
+	}
 	template.Resources[_bucket] = &s3.Bucket{
 		Tags: defaultTags,
 		// BucketName: ptr.String(PREFIX + "bucket" + SUFFIX), // optional; TODO: might want to fix this name to allow Pulumi destroy after stack deletion
-		AWSCloudFormationDeletionPolicy: "RetainExceptOnCreate",
+		AWSCloudFormationDeletionPolicy: bucketDeletionPolicy,
 		VersioningConfiguration: &s3.Bucket_VersioningConfiguration{
 			Status: "Enabled",
 		},
@@ -111,8 +118,8 @@ func createTemplate(stack string, tasks []types.Task, spot bool) *cloudformation
 	// * China (Ningxia) (cn-northwest-1)
 	// * AWS GovCloud (US-East) (us-gov-east-1)
 	// * AWS GovCloud (US-West) (us-gov-west-1)
-	images := make([]string, 0, len(tasks))
-	for _, task := range tasks {
+	images := make([]string, 0, len(containers))
+	for _, task := range containers {
 		image := task.Image
 		if repo, ok := strings.CutPrefix(image, awsecs.EcrPublicRegistry); ok {
 			const _pullThroughCache = "PullThroughCache"
@@ -292,18 +299,18 @@ func createTemplate(stack string, tasks []types.Task, spot bool) *cloudformation
 	}
 
 	// 7. ECS task definition
-	var totalCpu, totalMem float64
+	var totalCpu, totalMiB float64
 	var platform string
-	for _, task := range tasks {
-		totalCpu += task.Cpus
-		totalMem += float64(task.Memory)/1024/1024 + 6 // 6MB for the container overhead
+	for _, task := range containers {
+		totalCpu += float64(task.Cpus)
+		totalMiB += math.Max(float64(task.Memory)/1024/1024, 6) // 6MiB min for the container
 		if platform == "" {
 			platform = task.Platform
 		} else if platform != task.Platform {
 			panic("all tasks must have the same platform")
 		}
 	}
-	cpu, mem := awsecs.FixupFargateConfig(totalCpu, totalMem)
+	mCpu, mib := awsecs.FixupFargateConfig(totalCpu, totalMiB)
 	arch, os := awsecs.PlatformToArchOS(platform)
 	var archP, osP *string
 	if arch != "" {
@@ -315,15 +322,15 @@ func createTemplate(stack string, tasks []types.Task, spot bool) *cloudformation
 
 	var volumes []ecs.TaskDefinition_Volume
 	var containerDefinitions []ecs.TaskDefinition_ContainerDefinition
-	for i, task := range tasks {
-		for _, v := range task.Volumes {
+	for i, container := range containers {
+		for _, v := range container.Volumes {
 			volumes = append(volumes, ecs.TaskDefinition_Volume{
 				Name: ptr.String(v.Source),
 			})
 		}
 
-		volumesFrom := make([]ecs.TaskDefinition_VolumeFrom, 0, len(task.VolumesFrom))
-		for _, v := range task.VolumesFrom {
+		volumesFrom := make([]ecs.TaskDefinition_VolumeFrom, 0, len(container.VolumesFrom))
+		for _, v := range container.VolumesFrom {
 			parts := strings.SplitN(v, ":", 2)
 			ro := false
 			if len(parts) == 2 && parts[1] == "ro" {
@@ -335,8 +342,8 @@ func createTemplate(stack string, tasks []types.Task, spot bool) *cloudformation
 			})
 		}
 
-		mountPoints := make([]ecs.TaskDefinition_MountPoint, 0, len(task.Volumes))
-		for _, v := range task.Volumes {
+		mountPoints := make([]ecs.TaskDefinition_MountPoint, 0, len(container.Volumes))
+		for _, v := range container.Volumes {
 			mountPoints = append(mountPoints, ecs.TaskDefinition_MountPoint{
 				ContainerPath: ptr.String(v.Target),
 				SourceVolume:  ptr.String(v.Source),
@@ -344,11 +351,20 @@ func createTemplate(stack string, tasks []types.Task, spot bool) *cloudformation
 			})
 		}
 
+		var cpuShares *int
+		if container.Cpus > 0 {
+			cpuShares = ptr.Int(int(container.Cpus * 1024))
+		}
+		name := container.Name
+		if name == "" {
+			name = awsecs.ContainerName // TODO: backwards compat; remove this
+		}
 		def := ecs.TaskDefinition_ContainerDefinition{
-			Name:        task.Name,
+			Name:        name,
 			Image:       images[i],
-			StopTimeout: ptr.Int(120),
-			Essential:   task.Essential,
+			StopTimeout: ptr.Int(120), // TODO: make this configurable
+			Essential:   container.Essential,
+			Cpu:         cpuShares,
 			LogConfiguration: &ecs.TaskDefinition_LogConfiguration{
 				LogDriver: "awslogs",
 				Options: map[string]string{
@@ -357,17 +373,16 @@ func createTemplate(stack string, tasks []types.Task, spot bool) *cloudformation
 					"awslogs-stream-prefix": awsecs.AwsLogsStreamPrefix,
 				},
 			},
-			VolumesFrom:      volumesFrom,
-			MountPoints:      mountPoints,
-			EntryPoint:       task.EntryPoint,
-			Command:          task.Command,
-			WorkingDirectory: ptr.String("/app"), // TODO: make this configurable
+			VolumesFrom: volumesFrom,
+			MountPoints: mountPoints,
+			EntryPoint:  container.EntryPoint,
+			Command:     container.Command,
+			// WorkingDirectory: ptr.String("/app"), // TODO: make this configurable
 		}
 		containerDefinitions = append(containerDefinitions, def)
 	}
 
 	const _taskDefinition = "TaskDefinition"
-	const cdTaskDefName = awsecs.ContainerName + "-cd"
 	template.Resources[_taskDefinition] = &ecs.TaskDefinition{
 		Tags: defaultTags,
 		RuntimePlatform: &ecs.TaskDefinition_RuntimePlatform{
@@ -376,9 +391,9 @@ func createTemplate(stack string, tasks []types.Task, spot bool) *cloudformation
 		},
 		Volumes:                 volumes,
 		ContainerDefinitions:    containerDefinitions,
-		Cpu:                     ptr.String(strconv.FormatUint(uint64(cpu), 10)), // MilliCPU
+		Cpu:                     ptr.String(strconv.FormatUint(uint64(mCpu), 10)), // MilliCPU
 		ExecutionRoleArn:        cloudformation.RefPtr(_executionRole),
-		Memory:                  ptr.String(strconv.FormatUint(uint64(mem), 10)), // MiB
+		Memory:                  ptr.String(strconv.FormatUint(uint64(mib), 10)), // MiB
 		NetworkMode:             ptr.String("awsvpc"),
 		RequiresCompatibilities: []string{"FARGATE"},
 		TaskRoleArn:             cloudformation.RefPtr(_taskRole),

--- a/src/pkg/aws/ecs/cfn/template.go
+++ b/src/pkg/aws/ecs/cfn/template.go
@@ -307,7 +307,7 @@ func createTemplate(stack string, containers []types.Container, spot bool) *clou
 		if platform == "" {
 			platform = task.Platform
 		} else if platform != task.Platform {
-			panic("all tasks must have the same platform")
+			panic("all containers must have the same platform")
 		}
 	}
 	mCpu, mib := awsecs.FixupFargateConfig(totalCpu, totalMiB)

--- a/src/pkg/aws/ecs/common.go
+++ b/src/pkg/aws/ecs/common.go
@@ -25,25 +25,30 @@ type AwsEcs struct {
 	Spot            bool
 	SubNetID        string
 	TaskDefARN      string
-	VCpu            float64
 	VpcID           string
 }
 
-func PlatformToArch(platform string) *string {
-	if platform == "" {
-		return nil
+func PlatformToArchOS(platform string) (string, string) {
+	parts := strings.SplitN(platform, "/", 3) // Can be "os/arch/variant" like "linux/arm64/v8"
+
+	if len(parts) == 1 {
+		arch := parts[0]
+		return normalizedArch(arch), ""
+	} else {
+		os := parts[0]
+		arch := parts[1]
+		os = strings.ToUpper(os)
+		return normalizedArch(arch), os
 	}
-	parts := strings.SplitN(platform, "/", 3)
-	arch := parts[0]
-	if len(parts) >= 2 {
-		arch = parts[1]
-	}
+}
+
+func normalizedArch(arch string) string {
 	// From https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-runtimeplatform.html#cfn-ecs-taskdefinition-runtimeplatform-cpuarchitecture
 	arch = strings.ToUpper(arch)
 	if arch == "AMD64" {
 		arch = "X86_64"
 	}
-	return &arch
+	return arch
 }
 
 func (a *AwsEcs) SetVpcID(vpcId string) error {

--- a/src/pkg/aws/ecs/common_test.go
+++ b/src/pkg/aws/ecs/common_test.go
@@ -2,32 +2,33 @@ package ecs
 
 import (
 	"testing"
-
-	"github.com/aws/smithy-go/ptr"
 )
 
 func TestPlatformToArch(t *testing.T) {
 	tests := []struct {
 		platform string
-		want     *string
+		wantArch string
+		wantOs   string
 	}{
-		{"", nil},
-		{"blah", ptr.String("BLAH")}, // invalid platform
-		{"amd64", ptr.String("X86_64")},
-		{"arm64", ptr.String("ARM64")},
-		{"linux/amd64", ptr.String("X86_64")},
-		{"linux/arm64", ptr.String("ARM64")},
-		{"linux/arm64/v8", ptr.String("ARM64")},
-		{"linux/blah", ptr.String("BLAH")}, // invalid platform
+		{"", "", ""},
+		{"blah", "BLAH", ""}, // invalid platform
+		{"amd64", "X86_64", ""},
+		{"arm64", "ARM64", ""},
+		{"linux/amd64", "X86_64", "LINUX"},
+		{"linux/arm64", "ARM64", "LINUX"},
+		{"linux/arm64/v8", "ARM64", "LINUX"},
+		{"linux/blah", "BLAH", "LINUX"},     // invalid platform
+		{"windows/blah", "BLAH", "WINDOWS"}, // invalid platform
+		{"windows/amd64", "X86_64", "WINDOWS"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.platform, func(t *testing.T) {
-			if got := PlatformToArch(tt.platform); got == nil && tt.want != nil {
-				t.Errorf("PlatformToArch() = nil, want %v", tt.want)
-			} else if got != nil && tt.want == nil {
-				t.Errorf("PlatformToArch() = %v, want nil", *got)
-			} else if got != nil && tt.want != nil && *got != *tt.want {
-				t.Errorf("PlatformToArch() = %v, want %v", *got, *tt.want)
+			arch, os := PlatformToArchOS(tt.platform)
+			if os != tt.wantOs {
+				t.Errorf("PlatformToArch() os = %q, want %q", os, tt.wantOs)
+			}
+			if arch != tt.wantArch {
+				t.Errorf("PlatformToArch() arch = %q, want %q", arch, tt.wantArch)
 			}
 		})
 	}

--- a/src/pkg/cli/client/byoc.go
+++ b/src/pkg/cli/client/byoc.go
@@ -43,7 +43,7 @@ const (
 
 var (
 	// Changing this will cause issues if two clients with different versions are using the same account
-	cdImage = pkg.Getenv("DEFANG_CD_IMAGE", "public.ecr.aws/defang-io/cd:beta")
+	cdImage = pkg.Getenv("DEFANG_CD_IMAGE", "public.ecr.aws/defang-io/cd:public-beta")
 )
 
 type byocAws struct {

--- a/src/pkg/cli/client/byoc.go
+++ b/src/pkg/cli/client/byoc.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	r53Types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/smithy-go/ptr"
 	"github.com/bufbuild/connect-go"
 	"github.com/defang-io/defang/src/pkg"
 	"github.com/defang-io/defang/src/pkg/aws"
@@ -118,8 +119,37 @@ func (b *byocAws) setUp(ctx context.Context) error {
 	if b.setupDone {
 		return nil
 	}
-	// TODO: can we stick to the vanilla pulumi-nodejs image?
-	if err := b.driver.SetUp(ctx, cdImage, 512_000_000, "linux/amd64"); err != nil {
+	cdTaskName := cdTaskPrefix
+	tasks := []types.Task{
+		{
+			Image:     "pulumi/pulumi:latest",
+			Name:      awsecs.ContainerName,
+			Memory:    4 * 512_000_000, // 512 MiB
+			Essential: ptr.Bool(true),
+			VolumesFrom: []string{
+				cdTaskName,
+			},
+			EntryPoint: []string{"node", "lib/index.js"},
+		},
+		{
+			Image:     cdImage,
+			Name:      cdTaskName,
+			Essential: ptr.Bool(false),
+			Volumes: []types.TaskVolume{
+				{
+					Source:   "pulumi-plugins",
+					Target:   "/root/.pulumi/plugins",
+					ReadOnly: true,
+				},
+				{
+					Source:   "cd",
+					Target:   "/app",
+					ReadOnly: true,
+				},
+			},
+		},
+	}
+	if err := b.driver.SetUp(ctx, tasks); err != nil {
 		return annotateAwsError(err)
 	}
 

--- a/src/pkg/cmd/run.go
+++ b/src/pkg/cmd/run.go
@@ -15,14 +15,14 @@ func Run(ctx context.Context, region Region, image string, memory uint64, color 
 		return err
 	}
 
-	tasks := []types.Task{
+	containers := []types.Container{
 		{
 			Image:    image,
 			Memory:   memory,
 			Platform: platform,
 		},
 	}
-	if err := driver.SetUp(ctx, tasks); err != nil {
+	if err := driver.SetUp(ctx, containers); err != nil {
 		return err
 	}
 

--- a/src/pkg/cmd/run.go
+++ b/src/pkg/cmd/run.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/defang-io/defang/src/pkg/types"
 )
 
 func Run(ctx context.Context, region Region, image string, memory uint64, color Color, args []string, env map[string]string, platform, vpcId string) error {
@@ -13,7 +15,14 @@ func Run(ctx context.Context, region Region, image string, memory uint64, color 
 		return err
 	}
 
-	if err := driver.SetUp(ctx, image, memory, platform); err != nil {
+	tasks := []types.Task{
+		{
+			Image:    image,
+			Memory:   memory,
+			Platform: platform,
+		},
+	}
+	if err := driver.SetUp(ctx, tasks); err != nil {
 		return err
 	}
 

--- a/src/pkg/docker/run_test.go
+++ b/src/pkg/docker/run_test.go
@@ -16,7 +16,7 @@ func TestRun(t *testing.T) {
 
 	d := New()
 
-	err := d.SetUp(context.TODO(), []types.Task{{Image: "alpine:latest", Memory: 6 * 1024 * 1024, Platform: d.platform}})
+	err := d.SetUp(context.TODO(), []types.Container{{Image: "alpine:latest", Platform: d.platform}})
 
 	if err != nil {
 		t.Fatal(err)

--- a/src/pkg/docker/run_test.go
+++ b/src/pkg/docker/run_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/defang-io/defang/src/pkg/types"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -15,7 +16,8 @@ func TestRun(t *testing.T) {
 
 	d := New()
 
-	err := d.SetUp(context.TODO(), "alpine:latest", 6*1024*1024, d.platform)
+	err := d.SetUp(context.TODO(), []types.Task{{Image: "alpine:latest", Memory: 6 * 1024 * 1024, Platform: d.platform}})
+
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/pkg/docker/setup.go
+++ b/src/pkg/docker/setup.go
@@ -11,7 +11,7 @@ import (
 	pkgtypes "github.com/defang-io/defang/src/pkg/types"
 )
 
-func (d *Docker) SetUp(ctx context.Context, tasks []pkgtypes.Task) error {
+func (d *Docker) SetUp(ctx context.Context, tasks []pkgtypes.Container) error {
 	if len(tasks) != 1 {
 		return errors.New("only one task is supported with docker driver")
 	}

--- a/src/pkg/docker/setup.go
+++ b/src/pkg/docker/setup.go
@@ -11,11 +11,11 @@ import (
 	pkgtypes "github.com/defang-io/defang/src/pkg/types"
 )
 
-func (d *Docker) SetUp(ctx context.Context, tasks []pkgtypes.Container) error {
-	if len(tasks) != 1 {
-		return errors.New("only one task is supported with docker driver")
+func (d *Docker) SetUp(ctx context.Context, containers []pkgtypes.Container) error {
+	if len(containers) != 1 {
+		return errors.New("only one container is supported with docker driver")
 	}
-	task := tasks[0]
+	task := containers[0]
 	rc, err := d.ImagePull(ctx, task.Image, types.ImagePullOptions{Platform: task.Platform})
 	if err != nil {
 		return err

--- a/src/pkg/docker/setup.go
+++ b/src/pkg/docker/setup.go
@@ -2,22 +2,29 @@ package docker
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 
 	"github.com/docker/docker/api/types"
+
+	pkgtypes "github.com/defang-io/defang/src/pkg/types"
 )
 
-func (d *Docker) SetUp(ctx context.Context, image string, memory uint64, platform string) error {
-	rc, err := d.ImagePull(ctx, image, types.ImagePullOptions{Platform: platform})
+func (d *Docker) SetUp(ctx context.Context, tasks []pkgtypes.Task) error {
+	if len(tasks) != 1 {
+		return errors.New("only one task is supported with docker driver")
+	}
+	task := tasks[0]
+	rc, err := d.ImagePull(ctx, task.Image, types.ImagePullOptions{Platform: task.Platform})
 	if err != nil {
 		return err
 	}
 	defer rc.Close()
 	_, err = io.Copy(contextAwareWriter{ctx, os.Stderr}, rc) // FIXME: this outputs JSON to stderr
-	d.image = image
-	d.memory = memory
-	d.platform = platform
+	d.image = task.Image
+	d.memory = task.Memory
+	d.platform = task.Platform
 	return err
 }
 

--- a/src/pkg/local/local_test.go
+++ b/src/pkg/local/local_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/defang-io/defang/src/pkg/types"
 )
 
 func TestLocal(t *testing.T) {
@@ -11,7 +13,7 @@ func TestLocal(t *testing.T) {
 	ctx := context.TODO()
 
 	t.Run("SetUp", func(t *testing.T) {
-		if err := l.SetUp(ctx, "/bin/sh", 0, ""); err != nil {
+		if err := l.SetUp(ctx, []types.Container{{EntryPoint: []string{"/bin/sh"}}}); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/src/pkg/types/driver.go
+++ b/src/pkg/types/driver.go
@@ -10,8 +10,27 @@ const (
 
 type TaskID *string
 
+type Task struct {
+	Image       string
+	Name        string
+	Cpus        float64
+	Memory      uint64
+	Platform    string
+	Essential   *bool
+	Volumes     []TaskVolume
+	VolumesFrom []string
+	EntryPoint  []string
+	Command     []string
+}
+
+type TaskVolume struct {
+	Source   string
+	Target   string
+	ReadOnly bool
+}
+
 type Driver interface {
-	SetUp(ctx context.Context, image string, memory uint64, platform string) error
+	SetUp(ctx context.Context, tasks []Task) error
 	TearDown(ctx context.Context) error
 	Run(ctx context.Context, env map[string]string, args ...string) (TaskID, error)
 	Tail(ctx context.Context, taskID TaskID) error

--- a/src/pkg/types/driver.go
+++ b/src/pkg/types/driver.go
@@ -10,17 +10,17 @@ const (
 
 type TaskID *string
 
-type Task struct {
+type Container struct {
 	Image       string
 	Name        string
-	Cpus        float64
+	Cpus        float32
 	Memory      uint64
 	Platform    string
 	Essential   *bool
 	Volumes     []TaskVolume
-	VolumesFrom []string
+	VolumesFrom []string // container (default rw), container:rw, or container:ro
 	EntryPoint  []string
-	Command     []string
+	Command     []string // overridden by Run()
 }
 
 type TaskVolume struct {
@@ -30,7 +30,7 @@ type TaskVolume struct {
 }
 
 type Driver interface {
-	SetUp(ctx context.Context, tasks []Task) error
+	SetUp(ctx context.Context, containers []Container) error
 	TearDown(ctx context.Context) error
 	Run(ctx context.Context, env map[string]string, args ...string) (TaskID, error)
 	Tail(ctx context.Context, taskID TaskID) error


### PR DESCRIPTION
Extracted from #131 

* rename `Task` to `Container` (and `tasks` to `containers`)
* fixed ECS unit test
* fixed mem calculation (min 6MiB, not +6)
* set MinDelay=1 during stack delete/teardown
* removed hardcoded workingdir