### PR TITLE
cli: fix secret set prompt

### DIFF
--- a/src/pkg/aws/secrets.go
+++ b/src/pkg/aws/secrets.go
@@ -20,18 +20,16 @@ func IsParameterNotFoundError(err error) bool {
 	return errors.As(err, &e)
 }
 
-func (a *Aws) DeleteSecret(ctx context.Context, name string) error {
+func (a *Aws) DeleteSecrets(ctx context.Context, names ...string) error {
 	cfg, err := a.LoadConfig(ctx)
 	if err != nil {
 		return err
 	}
 
-	secretId := getSecretID(name)
-
 	svc := ssm.NewFromConfig(cfg)
 
-	_, err = svc.DeleteParameter(ctx, &ssm.DeleteParameterInput{
-		Name: secretId,
+	_, err = svc.DeleteParameters(ctx, &ssm.DeleteParametersInput{
+		Names: names, // works because getSecretID is a no-op
 	})
 	return err
 }

--- a/src/pkg/cli/client/byoc.go
+++ b/src/pkg/cli/client/byoc.go
@@ -471,12 +471,7 @@ func (b byocAws) PutSecret(ctx context.Context, secret *v1.SecretValue) error {
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid secret name; must be alphanumeric or _, cannot start with a number: %q", secret.Name))
 	}
 	fqn := b.getSecretID(secret.Name)
-	var err error
-	if secret.Value == "" {
-		err = b.driver.DeleteSecret(ctx, fqn)
-	} else {
-		err = b.driver.PutSecret(ctx, fqn, secret.Value)
-	}
+	err := b.driver.PutSecret(ctx, fqn, secret.Value)
 	return annotateAwsError(err)
 }
 
@@ -832,4 +827,15 @@ func (b *byocAws) BootstrapCommand(ctx context.Context, command string) (string,
 
 func (b *byocAws) Destroy(ctx context.Context) (string, error) {
 	return b.BootstrapCommand(ctx, "down")
+}
+
+func (b *byocAws) DeleteSecrets(ctx context.Context, secrets *v1.Secrets) error {
+	ids := make([]string, len(secrets.Names))
+	for i, name := range secrets.Names {
+		ids[i] = b.getSecretID(name)
+	}
+	if err := b.driver.DeleteSecrets(ctx, ids...); err != nil {
+		return annotateAwsError(err)
+	}
+	return nil
 }

--- a/src/pkg/cli/client/client.go
+++ b/src/pkg/cli/client/client.go
@@ -26,6 +26,7 @@ type Client interface {
 	DelegateSubdomainZone(context.Context, *v1.DelegateSubdomainZoneRequest) (*v1.DelegateSubdomainZoneResponse, error)
 	// Deprecated: Use Deploy or Destroy instead.
 	Delete(context.Context, *v1.DeleteRequest) (*v1.DeleteResponse, error)
+	DeleteSecrets(context.Context, *v1.Secrets) error
 	DeleteSubdomainZone(context.Context) error
 	Deploy(context.Context, *v1.DeployRequest) (*v1.DeployResponse, error)
 	Destroy(context.Context) (ETag, error)

--- a/src/pkg/cli/client/grpc.go
+++ b/src/pkg/cli/client/grpc.go
@@ -117,6 +117,16 @@ func (g GrpcClient) PutSecret(ctx context.Context, req *v1.SecretValue) error {
 	return err
 }
 
+func (g GrpcClient) DeleteSecrets(ctx context.Context, req *v1.Secrets) error {
+	// _, err := g.client.DeleteSecrets(ctx, &connect.Request[v1.Secrets]{Msg: req}); TODO: implement this in the server
+	var errs []error
+	for _, name := range req.Names {
+		_, err := g.client.PutSecret(ctx, &connect.Request[v1.SecretValue]{Msg: &v1.SecretValue{Name: name}})
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
 func (g GrpcClient) ListSecrets(ctx context.Context) (*v1.Secrets, error) {
 	return getMsg(g.client.ListSecrets(ctx, &connect.Request[emptypb.Empty]{}))
 }

--- a/src/pkg/cli/colorizer.go
+++ b/src/pkg/cli/colorizer.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	IsTerminal = term.IsTerminal(int(os.Stdout.Fd())) && os.Getenv("TERM") != ""
+	IsTerminal = term.IsTerminal(int(os.Stdout.Fd())) && term.IsTerminal(int(os.Stdin.Fd())) && os.Getenv("TERM") != ""
 	stdout     = termenv.NewOutput(os.Stdout)
 	stderr     = termenv.NewOutput(os.Stderr)
 	canColor   = doColor(stdout)
@@ -19,7 +19,6 @@ type Color = termenv.ANSIColor
 
 const (
 	Nop        Color = -1
-	Bright           = termenv.ANSIBrightWhite
 	BrightCyan       = termenv.ANSIBrightCyan
 	InfoColor        = termenv.ANSIBrightMagenta
 	ErrorColor       = termenv.ANSIBrightRed

--- a/src/pkg/cli/secretsDelete.go
+++ b/src/pkg/cli/secretsDelete.go
@@ -7,14 +7,14 @@ import (
 	v1 "github.com/defang-io/defang/src/protos/io/defang/v1"
 )
 
-func SecretsDelete(ctx context.Context, client client.Client, name string) error {
-	Debug(" - Deleting secret", name)
+func SecretsDelete(ctx context.Context, client client.Client, names ...string) error {
+	Debug(" - Deleting secret", names)
 
 	if DoDryRun {
 		return ErrDryRun
 	}
 
 	// FIXME: create dedicated DeleteSecret method in client proto
-	err := client.PutSecret(ctx, &v1.SecretValue{Name: name})
+	err := client.DeleteSecrets(ctx, &v1.Secrets{Names: names})
 	return err
 }

--- a/src/pkg/cli/secretsSet.go
+++ b/src/pkg/cli/secretsSet.go
@@ -12,7 +12,7 @@ func SecretsSet(ctx context.Context, client client.Client, name string, value st
 	Debug(" - Setting secret", name)
 
 	if value == "" {
-		return errors.New("value cannot be empty")
+		return errors.New("value cannot be empty") // FIXME: remove once we implement DeleteSecrets rpc
 	}
 
 	if DoDryRun {

--- a/src/pkg/types/driver.go
+++ b/src/pkg/types/driver.go
@@ -40,6 +40,7 @@ type Driver interface {
 	GetInfo(ctx context.Context, taskID TaskID) (*TaskInfo, error)
 	SetVpcID(vpcId string) error
 	PutSecret(ctx context.Context, name, value string) error
+	// DeleteSecrets(ctx context.Context, names ...string) error
 	ListSecrets(ctx context.Context) ([]string, error) // no values
 	CreateUploadURL(ctx context.Context, name string) (string, error)
 }

--- a/src/protos/io/defang/v1/defangv1connect/fabric.connect.go
+++ b/src/protos/io/defang/v1/defangv1connect/fabric.connect.go
@@ -78,6 +78,9 @@ const (
 	// FabricControllerPutSecretProcedure is the fully-qualified name of the FabricController's
 	// PutSecret RPC.
 	FabricControllerPutSecretProcedure = "/io.defang.v1.FabricController/PutSecret"
+	// FabricControllerDeleteSecretsProcedure is the fully-qualified name of the FabricController's
+	// DeleteSecrets RPC.
+	FabricControllerDeleteSecretsProcedure = "/io.defang.v1.FabricController/DeleteSecrets"
 	// FabricControllerListSecretsProcedure is the fully-qualified name of the FabricController's
 	// ListSecrets RPC.
 	FabricControllerListSecretsProcedure = "/io.defang.v1.FabricController/ListSecrets"
@@ -118,6 +121,7 @@ type FabricControllerClient interface {
 	SignEULA(context.Context, *connect_go.Request[emptypb.Empty]) (*connect_go.Response[emptypb.Empty], error)
 	CheckToS(context.Context, *connect_go.Request[emptypb.Empty]) (*connect_go.Response[emptypb.Empty], error)
 	PutSecret(context.Context, *connect_go.Request[v1.SecretValue]) (*connect_go.Response[emptypb.Empty], error)
+	DeleteSecrets(context.Context, *connect_go.Request[v1.Secrets]) (*connect_go.Response[emptypb.Empty], error)
 	ListSecrets(context.Context, *connect_go.Request[emptypb.Empty]) (*connect_go.Response[v1.Secrets], error)
 	CreateUploadURL(context.Context, *connect_go.Request[v1.UploadURLRequest]) (*connect_go.Response[v1.UploadURLResponse], error)
 	DelegateSubdomainZone(context.Context, *connect_go.Request[v1.DelegateSubdomainZoneRequest]) (*connect_go.Response[v1.DelegateSubdomainZoneResponse], error)
@@ -221,6 +225,11 @@ func NewFabricControllerClient(httpClient connect_go.HTTPClient, baseURL string,
 			baseURL+FabricControllerPutSecretProcedure,
 			opts...,
 		),
+		deleteSecrets: connect_go.NewClient[v1.Secrets, emptypb.Empty](
+			httpClient,
+			baseURL+FabricControllerDeleteSecretsProcedure,
+			opts...,
+		),
 		listSecrets: connect_go.NewClient[emptypb.Empty, v1.Secrets](
 			httpClient,
 			baseURL+FabricControllerListSecretsProcedure,
@@ -280,6 +289,7 @@ type fabricControllerClient struct {
 	signEULA                 *connect_go.Client[emptypb.Empty, emptypb.Empty]
 	checkToS                 *connect_go.Client[emptypb.Empty, emptypb.Empty]
 	putSecret                *connect_go.Client[v1.SecretValue, emptypb.Empty]
+	deleteSecrets            *connect_go.Client[v1.Secrets, emptypb.Empty]
 	listSecrets              *connect_go.Client[emptypb.Empty, v1.Secrets]
 	createUploadURL          *connect_go.Client[v1.UploadURLRequest, v1.UploadURLResponse]
 	delegateSubdomainZone    *connect_go.Client[v1.DelegateSubdomainZoneRequest, v1.DelegateSubdomainZoneResponse]
@@ -369,6 +379,11 @@ func (c *fabricControllerClient) PutSecret(ctx context.Context, req *connect_go.
 	return c.putSecret.CallUnary(ctx, req)
 }
 
+// DeleteSecrets calls io.defang.v1.FabricController.DeleteSecrets.
+func (c *fabricControllerClient) DeleteSecrets(ctx context.Context, req *connect_go.Request[v1.Secrets]) (*connect_go.Response[emptypb.Empty], error) {
+	return c.deleteSecrets.CallUnary(ctx, req)
+}
+
 // ListSecrets calls io.defang.v1.FabricController.ListSecrets.
 func (c *fabricControllerClient) ListSecrets(ctx context.Context, req *connect_go.Request[emptypb.Empty]) (*connect_go.Response[v1.Secrets], error) {
 	return c.listSecrets.CallUnary(ctx, req)
@@ -423,6 +438,7 @@ type FabricControllerHandler interface {
 	SignEULA(context.Context, *connect_go.Request[emptypb.Empty]) (*connect_go.Response[emptypb.Empty], error)
 	CheckToS(context.Context, *connect_go.Request[emptypb.Empty]) (*connect_go.Response[emptypb.Empty], error)
 	PutSecret(context.Context, *connect_go.Request[v1.SecretValue]) (*connect_go.Response[emptypb.Empty], error)
+	DeleteSecrets(context.Context, *connect_go.Request[v1.Secrets]) (*connect_go.Response[emptypb.Empty], error)
 	ListSecrets(context.Context, *connect_go.Request[emptypb.Empty]) (*connect_go.Response[v1.Secrets], error)
 	CreateUploadURL(context.Context, *connect_go.Request[v1.UploadURLRequest]) (*connect_go.Response[v1.UploadURLResponse], error)
 	DelegateSubdomainZone(context.Context, *connect_go.Request[v1.DelegateSubdomainZoneRequest]) (*connect_go.Response[v1.DelegateSubdomainZoneResponse], error)
@@ -522,6 +538,11 @@ func NewFabricControllerHandler(svc FabricControllerHandler, opts ...connect_go.
 		svc.PutSecret,
 		opts...,
 	)
+	fabricControllerDeleteSecretsHandler := connect_go.NewUnaryHandler(
+		FabricControllerDeleteSecretsProcedure,
+		svc.DeleteSecrets,
+		opts...,
+	)
 	fabricControllerListSecretsHandler := connect_go.NewUnaryHandler(
 		FabricControllerListSecretsProcedure,
 		svc.ListSecrets,
@@ -594,6 +615,8 @@ func NewFabricControllerHandler(svc FabricControllerHandler, opts ...connect_go.
 			fabricControllerCheckToSHandler.ServeHTTP(w, r)
 		case FabricControllerPutSecretProcedure:
 			fabricControllerPutSecretHandler.ServeHTTP(w, r)
+		case FabricControllerDeleteSecretsProcedure:
+			fabricControllerDeleteSecretsHandler.ServeHTTP(w, r)
 		case FabricControllerListSecretsProcedure:
 			fabricControllerListSecretsHandler.ServeHTTP(w, r)
 		case FabricControllerCreateUploadURLProcedure:
@@ -679,6 +702,10 @@ func (UnimplementedFabricControllerHandler) CheckToS(context.Context, *connect_g
 
 func (UnimplementedFabricControllerHandler) PutSecret(context.Context, *connect_go.Request[v1.SecretValue]) (*connect_go.Response[emptypb.Empty], error) {
 	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("io.defang.v1.FabricController.PutSecret is not implemented"))
+}
+
+func (UnimplementedFabricControllerHandler) DeleteSecrets(context.Context, *connect_go.Request[v1.Secrets]) (*connect_go.Response[emptypb.Empty], error) {
+	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("io.defang.v1.FabricController.DeleteSecrets is not implemented"))
 }
 
 func (UnimplementedFabricControllerHandler) ListSecrets(context.Context, *connect_go.Request[emptypb.Empty]) (*connect_go.Response[v1.Secrets], error) {

--- a/src/protos/io/defang/v1/fabric.pb.go
+++ b/src/protos/io/defang/v1/fabric.pb.go
@@ -2790,7 +2790,7 @@ var file_io_defang_v1_fabric_proto_rawDesc = []byte{
 	0x48, 0x54, 0x54, 0x50, 0x10, 0x03, 0x12, 0x09, 0x0a, 0x05, 0x48, 0x54, 0x54, 0x50, 0x32, 0x10,
 	0x04, 0x12, 0x08, 0x0a, 0x04, 0x47, 0x52, 0x50, 0x43, 0x10, 0x05, 0x2a, 0x1d, 0x0a, 0x04, 0x4d,
 	0x6f, 0x64, 0x65, 0x12, 0x08, 0x0a, 0x04, 0x48, 0x4f, 0x53, 0x54, 0x10, 0x00, 0x12, 0x0b, 0x0a,
-	0x07, 0x49, 0x4e, 0x47, 0x52, 0x45, 0x53, 0x53, 0x10, 0x01, 0x32, 0x87, 0x0d, 0x0a, 0x10, 0x46,
+	0x07, 0x49, 0x4e, 0x47, 0x52, 0x45, 0x53, 0x53, 0x10, 0x01, 0x32, 0xc7, 0x0d, 0x0a, 0x10, 0x46,
 	0x61, 0x62, 0x72, 0x69, 0x63, 0x43, 0x6f, 0x6e, 0x74, 0x72, 0x6f, 0x6c, 0x6c, 0x65, 0x72, 0x12,
 	0x3e, 0x0a, 0x09, 0x47, 0x65, 0x74, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x12, 0x16, 0x2e, 0x67,
 	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45,
@@ -2859,6 +2859,10 @@ var file_io_defang_v1_fabric_proto_rawDesc = []byte{
 	0x50, 0x75, 0x74, 0x53, 0x65, 0x63, 0x72, 0x65, 0x74, 0x12, 0x19, 0x2e, 0x69, 0x6f, 0x2e, 0x64,
 	0x65, 0x66, 0x61, 0x6e, 0x67, 0x2e, 0x76, 0x31, 0x2e, 0x53, 0x65, 0x63, 0x72, 0x65, 0x74, 0x56,
 	0x61, 0x6c, 0x75, 0x65, 0x1a, 0x16, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6d, 0x70, 0x74, 0x79, 0x12, 0x3e, 0x0a, 0x0d,
+	0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x53, 0x65, 0x63, 0x72, 0x65, 0x74, 0x73, 0x12, 0x15, 0x2e,
+	0x69, 0x6f, 0x2e, 0x64, 0x65, 0x66, 0x61, 0x6e, 0x67, 0x2e, 0x76, 0x31, 0x2e, 0x53, 0x65, 0x63,
+	0x72, 0x65, 0x74, 0x73, 0x1a, 0x16, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
 	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6d, 0x70, 0x74, 0x79, 0x12, 0x41, 0x0a, 0x0b,
 	0x4c, 0x69, 0x73, 0x74, 0x53, 0x65, 0x63, 0x72, 0x65, 0x74, 0x73, 0x12, 0x16, 0x2e, 0x67, 0x6f,
 	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6d,
@@ -3015,38 +3019,40 @@ var file_io_defang_v1_fabric_proto_depIdxs = []int32{
 	45, // 40: io.defang.v1.FabricController.SignEULA:input_type -> google.protobuf.Empty
 	45, // 41: io.defang.v1.FabricController.CheckToS:input_type -> google.protobuf.Empty
 	15, // 42: io.defang.v1.FabricController.PutSecret:input_type -> io.defang.v1.SecretValue
-	45, // 43: io.defang.v1.FabricController.ListSecrets:input_type -> google.protobuf.Empty
-	11, // 44: io.defang.v1.FabricController.CreateUploadURL:input_type -> io.defang.v1.UploadURLRequest
-	38, // 45: io.defang.v1.FabricController.DelegateSubdomainZone:input_type -> io.defang.v1.DelegateSubdomainZoneRequest
-	45, // 46: io.defang.v1.FabricController.DeleteSubdomainZone:input_type -> google.protobuf.Empty
-	45, // 47: io.defang.v1.FabricController.GetDelegateSubdomainZone:input_type -> google.protobuf.Empty
-	45, // 48: io.defang.v1.FabricController.WhoAmI:input_type -> google.protobuf.Empty
-	3,  // 49: io.defang.v1.FabricController.Track:input_type -> io.defang.v1.TrackRequest
-	18, // 50: io.defang.v1.FabricController.GetStatus:output_type -> io.defang.v1.Status
-	19, // 51: io.defang.v1.FabricController.GetVersion:output_type -> io.defang.v1.Version
-	17, // 52: io.defang.v1.FabricController.Token:output_type -> io.defang.v1.TokenResponse
-	45, // 53: io.defang.v1.FabricController.RevokeToken:output_type -> google.protobuf.Empty
-	22, // 54: io.defang.v1.FabricController.Tail:output_type -> io.defang.v1.TailResponse
-	13, // 55: io.defang.v1.FabricController.Update:output_type -> io.defang.v1.ServiceInfo
-	5,  // 56: io.defang.v1.FabricController.Deploy:output_type -> io.defang.v1.DeployResponse
-	13, // 57: io.defang.v1.FabricController.Get:output_type -> io.defang.v1.ServiceInfo
-	7,  // 58: io.defang.v1.FabricController.Delete:output_type -> io.defang.v1.DeleteResponse
-	45, // 59: io.defang.v1.FabricController.Publish:output_type -> google.protobuf.Empty
-	37, // 60: io.defang.v1.FabricController.Subscribe:output_type -> io.defang.v1.SubscribeResponse
-	23, // 61: io.defang.v1.FabricController.GetServices:output_type -> io.defang.v1.ListServicesResponse
-	10, // 62: io.defang.v1.FabricController.GenerateFiles:output_type -> io.defang.v1.GenerateFilesResponse
-	45, // 63: io.defang.v1.FabricController.SignEULA:output_type -> google.protobuf.Empty
-	45, // 64: io.defang.v1.FabricController.CheckToS:output_type -> google.protobuf.Empty
-	45, // 65: io.defang.v1.FabricController.PutSecret:output_type -> google.protobuf.Empty
-	14, // 66: io.defang.v1.FabricController.ListSecrets:output_type -> io.defang.v1.Secrets
-	12, // 67: io.defang.v1.FabricController.CreateUploadURL:output_type -> io.defang.v1.UploadURLResponse
-	39, // 68: io.defang.v1.FabricController.DelegateSubdomainZone:output_type -> io.defang.v1.DelegateSubdomainZoneResponse
-	45, // 69: io.defang.v1.FabricController.DeleteSubdomainZone:output_type -> google.protobuf.Empty
-	39, // 70: io.defang.v1.FabricController.GetDelegateSubdomainZone:output_type -> io.defang.v1.DelegateSubdomainZoneResponse
-	40, // 71: io.defang.v1.FabricController.WhoAmI:output_type -> io.defang.v1.WhoAmIResponse
-	45, // 72: io.defang.v1.FabricController.Track:output_type -> google.protobuf.Empty
-	50, // [50:73] is the sub-list for method output_type
-	27, // [27:50] is the sub-list for method input_type
+	14, // 43: io.defang.v1.FabricController.DeleteSecrets:input_type -> io.defang.v1.Secrets
+	45, // 44: io.defang.v1.FabricController.ListSecrets:input_type -> google.protobuf.Empty
+	11, // 45: io.defang.v1.FabricController.CreateUploadURL:input_type -> io.defang.v1.UploadURLRequest
+	38, // 46: io.defang.v1.FabricController.DelegateSubdomainZone:input_type -> io.defang.v1.DelegateSubdomainZoneRequest
+	45, // 47: io.defang.v1.FabricController.DeleteSubdomainZone:input_type -> google.protobuf.Empty
+	45, // 48: io.defang.v1.FabricController.GetDelegateSubdomainZone:input_type -> google.protobuf.Empty
+	45, // 49: io.defang.v1.FabricController.WhoAmI:input_type -> google.protobuf.Empty
+	3,  // 50: io.defang.v1.FabricController.Track:input_type -> io.defang.v1.TrackRequest
+	18, // 51: io.defang.v1.FabricController.GetStatus:output_type -> io.defang.v1.Status
+	19, // 52: io.defang.v1.FabricController.GetVersion:output_type -> io.defang.v1.Version
+	17, // 53: io.defang.v1.FabricController.Token:output_type -> io.defang.v1.TokenResponse
+	45, // 54: io.defang.v1.FabricController.RevokeToken:output_type -> google.protobuf.Empty
+	22, // 55: io.defang.v1.FabricController.Tail:output_type -> io.defang.v1.TailResponse
+	13, // 56: io.defang.v1.FabricController.Update:output_type -> io.defang.v1.ServiceInfo
+	5,  // 57: io.defang.v1.FabricController.Deploy:output_type -> io.defang.v1.DeployResponse
+	13, // 58: io.defang.v1.FabricController.Get:output_type -> io.defang.v1.ServiceInfo
+	7,  // 59: io.defang.v1.FabricController.Delete:output_type -> io.defang.v1.DeleteResponse
+	45, // 60: io.defang.v1.FabricController.Publish:output_type -> google.protobuf.Empty
+	37, // 61: io.defang.v1.FabricController.Subscribe:output_type -> io.defang.v1.SubscribeResponse
+	23, // 62: io.defang.v1.FabricController.GetServices:output_type -> io.defang.v1.ListServicesResponse
+	10, // 63: io.defang.v1.FabricController.GenerateFiles:output_type -> io.defang.v1.GenerateFilesResponse
+	45, // 64: io.defang.v1.FabricController.SignEULA:output_type -> google.protobuf.Empty
+	45, // 65: io.defang.v1.FabricController.CheckToS:output_type -> google.protobuf.Empty
+	45, // 66: io.defang.v1.FabricController.PutSecret:output_type -> google.protobuf.Empty
+	45, // 67: io.defang.v1.FabricController.DeleteSecrets:output_type -> google.protobuf.Empty
+	14, // 68: io.defang.v1.FabricController.ListSecrets:output_type -> io.defang.v1.Secrets
+	12, // 69: io.defang.v1.FabricController.CreateUploadURL:output_type -> io.defang.v1.UploadURLResponse
+	39, // 70: io.defang.v1.FabricController.DelegateSubdomainZone:output_type -> io.defang.v1.DelegateSubdomainZoneResponse
+	45, // 71: io.defang.v1.FabricController.DeleteSubdomainZone:output_type -> google.protobuf.Empty
+	39, // 72: io.defang.v1.FabricController.GetDelegateSubdomainZone:output_type -> io.defang.v1.DelegateSubdomainZoneResponse
+	40, // 73: io.defang.v1.FabricController.WhoAmI:output_type -> io.defang.v1.WhoAmIResponse
+	45, // 74: io.defang.v1.FabricController.Track:output_type -> google.protobuf.Empty
+	51, // [51:75] is the sub-list for method output_type
+	27, // [27:51] is the sub-list for method input_type
 	27, // [27:27] is the sub-list for extension type_name
 	27, // [27:27] is the sub-list for extension extendee
 	0,  // [0:27] is the sub-list for field type_name

--- a/src/protos/io/defang/v1/fabric.proto
+++ b/src/protos/io/defang/v1/fabric.proto
@@ -42,11 +42,11 @@ service FabricController {
   rpc CheckToS(google.protobuf.Empty) returns (google.protobuf.Empty);
 
   rpc PutSecret(SecretValue) returns (google.protobuf.Empty);
+  rpc DeleteSecrets(Secrets) returns (google.protobuf.Empty);
   rpc ListSecrets(google.protobuf.Empty) returns (Secrets) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }; // no values
   rpc CreateUploadURL(UploadURLRequest) returns (UploadURLResponse);
-  // rpc DeleteSecret(SecretValue) returns (google.protobuf.Empty);
 
   rpc DelegateSubdomainZone(DelegateSubdomainZoneRequest)
       returns (DelegateSubdomainZoneResponse);


### PR DESCRIPTION
- `echo abc | defang secret set -n asdf` was broken (would show prompt, did not detect pipe)
- support `defang secret delete -n foo -n bar`
- fix secret prompt coloring (by using survey lib; note #95 )
- support multi-line secrets