### PR TITLE
feat: ls parity between BYOC and playground

### DIFF
--- a/src/cmd/cli/main.go
+++ b/src/cmd/cli/main.go
@@ -264,13 +264,19 @@ var getServicesCmd = &cobra.Command{
 	Aliases:     []string{"getServices", "ls", "list"},
 	Short:       "Get list of services on the cluster",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		track("Services Invoked")
+		long, _ := cmd.Flags().GetBool("long")
 
-		err := cli.GetServices(cmd.Context(), client)
+		track("Services Invoked", P{"long", long})
+
+		err := cli.GetServices(cmd.Context(), client, long)
 		if err != nil {
 			return err
 		}
-		// printDefangHint("To get more information about a service, do:", "get service <name>")
+
+		if !long {
+			printDefangHint("To see more information about your services, do:", cmd.CalledAs()+" -l")
+		}
+
 		return nil
 	},
 }
@@ -514,11 +520,7 @@ var composeRestartCmd = &cobra.Command{
 
 		track("Compose-Restart Invoked", P{"file", filePath})
 
-		_, err := cli.ComposeRestart(cmd.Context(), client, project)
-		if err != nil {
-			return err
-		}
-		return nil
+		return cli.ComposeRestart(cmd.Context(), client, project)
 	},
 }
 
@@ -642,11 +644,7 @@ var restartCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		track("Restart Invoked", P{"services", args})
 
-		_, err := cli.Restart(cmd.Context(), client, args...)
-		if err != nil {
-			return err
-		}
-		return nil
+		return cli.Restart(cmd.Context(), client, args...)
 	},
 }
 
@@ -804,7 +802,7 @@ var tosCmd = &cobra.Command{
 			return cli.InteractiveAgreeToS(cmd.Context(), client)
 		}
 
-		printDefangHint("To agree to the terms of service, do:", "terms --agree-tos")
+		printDefangHint("To agree to the terms of service, do:", cmd.CalledAs()+" --agree-tos")
 		return nil
 	},
 }
@@ -859,6 +857,7 @@ func main() {
 	rootCmd.AddCommand(generateCmd)
 
 	// Get Services Command
+	getServicesCmd.Flags().BoolP("long", "l", false, "Show more details")
 	rootCmd.AddCommand(getServicesCmd)
 
 	// Get Status Command

--- a/src/pkg/cli/client/byoc.go
+++ b/src/pkg/cli/client/byoc.go
@@ -868,3 +868,7 @@ func (b *byocAws) DeleteSecrets(ctx context.Context, secrets *v1.Secrets) error 
 	}
 	return nil
 }
+
+func (b *byocAws) Restart(ctx context.Context, names ...string) error {
+	return errors.New("not yet implemented for BYOC; please use the AWS ECS dashboard") // FIXME: implement this for BYOC
+}

--- a/src/pkg/cli/client/client.go
+++ b/src/pkg/cli/client/client.go
@@ -38,6 +38,7 @@ type Client interface {
 	ListSecrets(context.Context) (*v1.Secrets, error)
 	Publish(context.Context, *v1.PublishRequest) error
 	PutSecret(context.Context, *v1.SecretValue) error
+	Restart(context.Context, ...string) error
 	RevokeToken(context.Context) error
 	Tail(context.Context, *v1.TailRequest) (ServerStream[v1.TailResponse], error)
 	TearDown(context.Context) error

--- a/src/pkg/cli/composeRestart.go
+++ b/src/pkg/cli/composeRestart.go
@@ -6,12 +6,11 @@ import (
 
 	composeTypes "github.com/compose-spec/compose-go/v2/types"
 	"github.com/defang-io/defang/src/pkg/cli/client"
-	v1 "github.com/defang-io/defang/src/protos/io/defang/v1"
 )
 
-func ComposeRestart(ctx context.Context, client client.Client, project *composeTypes.Project) ([]*v1.ServiceInfo, error) {
+func ComposeRestart(ctx context.Context, client client.Client, project *composeTypes.Project) error {
 	if project == nil {
-		return nil, &ComposeError{errors.New("no project found")}
+		return &ComposeError{errors.New("no project found")}
 	}
 	names := make([]string, 0, len(project.Services))
 	for _, service := range project.Services {

--- a/src/pkg/cli/getServices.go
+++ b/src/pkg/cli/getServices.go
@@ -4,12 +4,19 @@ import (
 	"context"
 
 	"github.com/defang-io/defang/src/pkg/cli/client"
+	defangv1 "github.com/defang-io/defang/src/protos/io/defang/v1"
 )
 
-func GetServices(ctx context.Context, client client.Client) error {
+func GetServices(ctx context.Context, client client.Client, long bool) error {
 	serviceList, err := client.GetServices(ctx)
 	if err != nil {
 		return err
+	}
+
+	if !long {
+		for _, si := range serviceList.Services {
+			*si = defangv1.ServiceInfo{Service: &defangv1.Service{Name: si.Service.Name}}
+		}
 	}
 
 	PrintObject("", serviceList)

--- a/src/pkg/cli/restart.go
+++ b/src/pkg/cli/restart.go
@@ -4,30 +4,14 @@ import (
 	"context"
 
 	"github.com/defang-io/defang/src/pkg/cli/client"
-	v1 "github.com/defang-io/defang/src/protos/io/defang/v1"
 )
 
-func Restart(ctx context.Context, client client.Client, names ...string) ([]*v1.ServiceInfo, error) {
+func Restart(ctx context.Context, client client.Client, names ...string) error {
 	Debug(" - Restarting service", names)
 
-	// For now, we'll just get the service info and pass it to deploy as-is.
-	services := make([]*v1.Service, 0, len(names))
-	for _, name := range names {
-		serviceInfo, err := client.Get(ctx, (&v1.ServiceID{Name: name}))
-		if err != nil {
-			Warn(" ! Failed to get service", name, err)
-			continue
-		}
-		services = append(services, serviceInfo.Service)
-	}
-
 	if DoDryRun {
-		return nil, ErrDryRun
+		return ErrDryRun
 	}
 
-	resp, err := client.Deploy(ctx, &v1.DeployRequest{Services: services})
-	if err != nil {
-		return nil, err
-	}
-	return resp.Services, nil
+	return client.Restart(ctx, names...)
 }


### PR DESCRIPTION
Both BYOC and Playground show only names now:
```
$ defang ls
 * Connecting to fabric-prod1.defang.dev:443
services:
    - service:
        name: api-production
    - service:
        name: hasura-production
    - service:
        name: heimdall-production
    - service:
        name: kratos-production
    - service:
        name: web-production


To see more information about your services, do:

  defang ls -l
```