### PR TITLE
ensure Dockerfile is always in context

### DIFF
--- a/src/tests/testproj/.dockerignore
+++ b/src/tests/testproj/.dockerignore
@@ -15,3 +15,6 @@
 **/node_modules
 **/Thumbs.db
 defang
+
+# Test to ensure Dockerfile is always included, even when excluded by .dockerignore
+Dockerfile


### PR DESCRIPTION
…because the builder needs it

Same as https://github.com/defang-io/pulumi-defang/commit/ffb88e84da80e26694714f1bc43a3828779cfb4b
