### PR TITLE
nix: update vendorHash

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,7 +44,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Check nix-shell default.nix
-        run: nix-shell default.nix --run defang
+        run: nix-shell --pure -E 'with import <nixpkgs> {}; mkShell { buildInputs = [ (import ./default.nix {}) ]; }' --run defang
 
   # go-byoc-test:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,6 +33,19 @@ jobs:
           go mod tidy
           git diff --exit-code go.mod go.sum || { echo "Go modules are not up to date"; exit 1; }
 
+  nix-shell-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v26
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Check nix-shell default.nix
+        run: nix-shell default.nix --run defang
+
   # go-byoc-test:
   #   runs-on: ubuntu-latest
   #   steps:
@@ -65,6 +78,7 @@ jobs:
 
   go-playground-test:
     runs-on: ubuntu-latest
+    needs: go-test
     steps:
       - uses: actions/checkout@v4
 
@@ -108,7 +122,7 @@ jobs:
         working-directory: src
 
       - name: Install Nix (for nix-prefetch-url)
-        uses: cachix/install-nix-action@v23
+        uses: cachix/install-nix-action@v26
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5

--- a/pkgs/defang/cli.nix
+++ b/pkgs/defang/cli.nix
@@ -3,9 +3,11 @@ buildGoModule {
   pname = "defang-cli";
   version = "git";
   src = ../../src;
-  vendorHash = "sha256-C358K4uQaoM8ZorwEVLc9nQnRqBMj8TcYBnuKausL5M=";
+  vendorHash = "sha256-uxPeGtKw/DZwWZwFHuNloMc2LIsy9s/nsmHFttbMKC8=";
 
   subPackages = [ "cmd/cli" ];
+
+  doCheck = false; # some unit tests need internet access
 
   postInstall = ''
     mv $out/bin/cli $out/bin/defang


### PR DESCRIPTION
and add CI gate to catch mistaken `vendorHash`.

The flake is updated automatically, but we have no automation to update vendorHash (and commit to GIT) so for now adding a CI check. Should check https://goreleaser.com/customization/nix/