### PR TITLE
Always include anonymous ID

### DIFF
--- a/src/cmd/cli/track.go
+++ b/src/cmd/cli/track.go
@@ -42,16 +42,16 @@ func flushAllTracking() {
 func trackCmd(cmd *cobra.Command, verb string, props ...P) {
 	command := "Unknown"
 	if cmd != nil {
+		command = cmd.Name()
 		// Ignore tracking for shell completion requests
-		if cmd.Name() == cobra.ShellCompRequestCmd {
+		if command == cobra.ShellCompRequestCmd {
 			return
 		}
 		calledAs := cmd.CalledAs()
-		command = cmd.Use
 		cmd.VisitParents(func(c *cobra.Command) {
 			calledAs = c.CalledAs() + " " + calledAs
 			if c.HasParent() { // skip root command
-				command = c.Use + "-" + command
+				command = c.Name() + "-" + command
 			}
 		})
 		props = append(props, P{Name: "CalledAs", Value: calledAs})

--- a/src/pkg/cli/client/interceptor.go
+++ b/src/pkg/cli/client/interceptor.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"context"
+
+	"github.com/bufbuild/connect-go"
+)
+
+type anonInterceptor struct {
+	anonId string
+}
+
+func NewAnonInterceptor(anonId string) connect.Interceptor {
+	return &anonInterceptor{anonId: anonId}
+}
+
+func (a *anonInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		req.Header().Set("x-anon-id", a.anonId)
+		return next(ctx, req)
+	}
+}
+
+func (a *anonInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return func(ctx context.Context, spec connect.Spec) connect.StreamingClientConn {
+		conn := next(ctx, spec)
+		conn.RequestHeader().Set("x-anon-id", a.anonId)
+		return conn
+	}
+}
+
+func (anonInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return next
+}


### PR DESCRIPTION
Add an interceptor that add an `x-anon-id` header with the anonymous ID for correctly matching the events that happen before login.

fixes https://github.com/defang-io/defang-mvp/issues/558