### PR TITLE
Show portal url in command line response when deploying to defang cluster

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -621,9 +621,11 @@ var composeCmd = &cobra.Command{
 	Short:   "Work with local Compose files",
 }
 
-func printPortalURL() {
+func printPortalURL(serviceInfos []*v1.ServiceInfo) {
 	cli.Info(" * Monitor your services' status in the defang portal")
-	cli.Println(cli.Nop, "   -", SERVICE_PORTAL_URL)
+	for _, serviceInfo := range serviceInfos {
+		cli.Println(cli.Nop, "   - ", SERVICE_PORTAL_URL+"/"+serviceInfo.Service.Name)
+	}
 }
 
 func printEndpoints(serviceInfos []*v1.ServiceInfo) {
@@ -646,8 +648,7 @@ func printEndpoints(serviceInfos []*v1.ServiceInfo) {
 }
 
 func isCommandUsingDefangPlayground(cmd *cobra.Command) bool {
-	var defangDefaultCluster = pkg.Getenv("DEFANG_FABRIC", cli.DefaultCluster)
-	return cmd.Flag("cluster").Value.String() == defangDefaultCluster
+	return *(cmd.Flag("provider").Value.(*cliClient.Provider)) == cliClient.ProviderDefang
 }
 
 var composeUpCmd = &cobra.Command{
@@ -666,7 +667,7 @@ var composeUpCmd = &cobra.Command{
 		}
 
 		if isCommandUsingDefangPlayground(cmd) {
-			printPortalURL()
+			printPortalURL(deploy.Services)
 		}
 
 		printEndpoints(deploy.Services)
@@ -706,7 +707,7 @@ var composeStartCmd = &cobra.Command{
 		}
 
 		if isCommandUsingDefangPlayground(cmd) {
-			printPortalURL()
+			printPortalURL(deploy.Services)
 		}
 
 		printEndpoints(deploy.Services)

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -647,8 +647,8 @@ func printEndpoints(serviceInfos []*v1.ServiceInfo) {
 	}
 }
 
-func isCommandUsingDefangPlayground(cmd *cobra.Command) bool {
-	return *(cmd.Flag("provider").Value.(*cliClient.Provider)) == cliClient.ProviderDefang
+func isCommandUsingDefangPlayground(provider *cliClient.Provider) bool {
+	return *provider == cliClient.ProviderDefang
 }
 
 var composeUpCmd = &cobra.Command{
@@ -666,7 +666,8 @@ var composeUpCmd = &cobra.Command{
 			return err
 		}
 
-		if isCommandUsingDefangPlayground(cmd) {
+		provider := cmd.Flag("provider").Value.(*cliClient.Provider)
+		if isCommandUsingDefangPlayground(provider) {
 			printPortalURL(deploy.Services)
 		}
 
@@ -706,7 +707,8 @@ var composeStartCmd = &cobra.Command{
 			return err
 		}
 
-		if isCommandUsingDefangPlayground(cmd) {
+		provider := cmd.Flag("provider").Value.(*cliClient.Provider)
+		if isCommandUsingDefangPlayground(provider) {
 			printPortalURL(deploy.Services)
 		}
 

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -621,10 +621,13 @@ var composeCmd = &cobra.Command{
 	Short:   "Work with local Compose files",
 }
 
-func printPortalURL(serviceInfos []*v1.ServiceInfo) {
-	cli.Info(" * Monitor your services' status in the defang portal")
-	for _, serviceInfo := range serviceInfos {
-		cli.Println(cli.Nop, "   - ", SERVICE_PORTAL_URL+"/"+serviceInfo.Service.Name)
+func printPlaygroundPortalServiceURLs(provider *cliClient.Provider, serviceInfos []*v1.ServiceInfo) {
+	// We can only show services deployed to the defang SaaS environment.
+	if *provider == cliClient.ProviderDefang {
+		cli.Info(" * Monitor your services' status in the defang portal")
+		for _, serviceInfo := range serviceInfos {
+			cli.Println(cli.Nop, "   - ", SERVICE_PORTAL_URL+"/"+serviceInfo.Service.Name)
+		}
 	}
 }
 
@@ -647,10 +650,6 @@ func printEndpoints(serviceInfos []*v1.ServiceInfo) {
 	}
 }
 
-func isCommandUsingDefangPlayground(provider *cliClient.Provider) bool {
-	return *provider == cliClient.ProviderDefang
-}
-
 var composeUpCmd = &cobra.Command{
 	Use:         "up",
 	Annotations: authNeededAnnotation,
@@ -667,10 +666,7 @@ var composeUpCmd = &cobra.Command{
 		}
 
 		provider := cmd.Flag("provider").Value.(*cliClient.Provider)
-		if isCommandUsingDefangPlayground(provider) {
-			printPortalURL(deploy.Services)
-		}
-
+		printPlaygroundPortalServiceURLs(provider, deploy.Services)
 		printEndpoints(deploy.Services)
 
 		if detach {
@@ -708,10 +704,7 @@ var composeStartCmd = &cobra.Command{
 		}
 
 		provider := cmd.Flag("provider").Value.(*cliClient.Provider)
-		if isCommandUsingDefangPlayground(provider) {
-			printPortalURL(deploy.Services)
-		}
-
+		printPlaygroundPortalServiceURLs(provider, deploy.Services)
 		printEndpoints(deploy.Services)
 
 		command := "tail"

--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -26,6 +26,9 @@ import (
 	"golang.org/x/mod/semver"
 )
 
+const DEFANG_PORTAL_HOST = "portal.defang.dev"
+const SERVICE_PORTAL_URL = "https://" + DEFANG_PORTAL_HOST + "/service"
+
 const authNeeded = "auth-needed" // annotation to indicate that a command needs authorization
 var authNeededAnnotation = map[string]string{authNeeded: ""}
 
@@ -618,6 +621,11 @@ var composeCmd = &cobra.Command{
 	Short:   "Work with local Compose files",
 }
 
+func printPortalURL() {
+	cli.Info(" * Monitor your services' status in the defang portal")
+	cli.Println(cli.Nop, "   -", SERVICE_PORTAL_URL)
+}
+
 func printEndpoints(serviceInfos []*v1.ServiceInfo) {
 	for _, serviceInfo := range serviceInfos {
 		andEndpoints := ""
@@ -637,6 +645,11 @@ func printEndpoints(serviceInfos []*v1.ServiceInfo) {
 	}
 }
 
+func isCommandUsingDefangPlayground(cmd *cobra.Command) bool {
+	var defangDefaultCluster = pkg.Getenv("DEFANG_FABRIC", cli.DefaultCluster)
+	return cmd.Flag("cluster").Value.String() == defangDefaultCluster
+}
+
 var composeUpCmd = &cobra.Command{
 	Use:         "up",
 	Annotations: authNeededAnnotation,
@@ -650,6 +663,10 @@ var composeUpCmd = &cobra.Command{
 		deploy, err := cli.ComposeStart(cmd.Context(), client, project, force)
 		if err != nil {
 			return err
+		}
+
+		if isCommandUsingDefangPlayground(cmd) {
+			printPortalURL()
 		}
 
 		printEndpoints(deploy.Services)
@@ -686,6 +703,10 @@ var composeStartCmd = &cobra.Command{
 		deploy, err := cli.ComposeStart(cmd.Context(), client, project, force)
 		if err != nil {
 			return err
+		}
+
+		if isCommandUsingDefangPlayground(cmd) {
+			printPortalURL()
 		}
 
 		printEndpoints(deploy.Services)


### PR DESCRIPTION
#97 

Add portal link to command line response on **defang compose up** and **defang compose start**

<img width="491" alt="Screenshot 2024-04-09 at 2 03 44 PM" src="https://github.com/defang-io/defang/assets/7478236/e1882897-4303-4a28-a49a-2de9c6c70ce2">
