### PR TITLE
fix: use project name for private zone

### DIFF
--- a/src/pkg/cli/client/byoc/byoc.go
+++ b/src/pkg/cli/client/byoc/byoc.go
@@ -1,8 +1,0 @@
-package byoc
-
-import (
-	"github.com/defang-io/defang/src/pkg/cli/client"
-	"github.com/defang-io/defang/src/pkg/cli/client/byoc/clouds"
-)
-
-var _ client.Client = (*clouds.ByocAws)(nil)

--- a/src/pkg/cli/client/byoc/clouds/aws.go
+++ b/src/pkg/cli/client/byoc/clouds/aws.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"sort"
@@ -30,7 +28,6 @@ import (
 	"github.com/defang-io/defang/src/pkg/clouds/aws/ecs"
 	"github.com/defang-io/defang/src/pkg/clouds/aws/ecs/cfn"
 	"github.com/defang-io/defang/src/pkg/http"
-	"github.com/defang-io/defang/src/pkg/logs"
 	"github.com/defang-io/defang/src/pkg/quota"
 	"github.com/defang-io/defang/src/pkg/types"
 	defangv1 "github.com/defang-io/defang/src/protos/io/defang/v1"
@@ -42,8 +39,8 @@ type ByocAws struct {
 	*client.GrpcClient
 
 	cdTasks                 map[string]ecs.TaskArn
-	CustomDomain            string
-	Driver                  *cfn.AwsEcs
+	customDomain            string
+	driver                  *cfn.AwsEcs
 	privateDomain           string
 	privateLbIps            []string
 	publicNatIps            []string
@@ -51,9 +48,11 @@ type ByocAws struct {
 	pulumiStack             string
 	quota                   quota.Quotas
 	setupDone               bool
-	TenantID                string
+	tenantID                string
 	shouldDelegateSubdomain bool
 }
+
+var _ client.Client = (*ByocAws)(nil)
 
 func NewByocAWS(tenantId types.TenantID, project string, defClient *client.GrpcClient) *ByocAws {
 	// Resource naming (stack/stackDir) requires a project name
@@ -63,10 +62,11 @@ func NewByocAWS(tenantId types.TenantID, project string, defClient *client.GrpcC
 	b := &ByocAws{
 		GrpcClient:    defClient,
 		cdTasks:       make(map[string]ecs.TaskArn),
-		CustomDomain:  "",
-		Driver:        cfn.New(CdTaskPrefix, aws.Region("")), // default region
-		pulumiProject: project,                               // TODO: multi-project support
-		pulumiStack:   "beta",                                // TODO: make customizable
+		customDomain:  "",
+		driver:        cfn.New(CdTaskPrefix, aws.Region("")), // default region
+		privateDomain: dnsSafeLabel(project) + ".internal",
+		pulumiProject: project, // TODO: multi-project support
+		pulumiStack:   "beta",  // TODO: make customizable
 		quota: quota.Quotas{
 			// These serve mostly to pevent fat-finger errors in the CLI or Compose files
 			Cpus:       16,
@@ -76,11 +76,10 @@ func NewByocAWS(tenantId types.TenantID, project string, defClient *client.GrpcC
 			Services:   40,
 			ShmSizeMiB: 30720,
 		},
-		TenantID: string(tenantId),
+		tenantID: string(tenantId),
 		// privateLbIps:  nil,                                                 // TODO: grab these from the AWS API or outputs
 		// publicNatIps:  nil,                                                 // TODO: grab these from the AWS API or outputs
 	}
-	b.privateDomain = b.getProjectDomain("internal")
 	return b
 }
 
@@ -121,16 +120,16 @@ func (b *ByocAws) setUp(ctx context.Context) error {
 			},
 		},
 	}
-	if err := b.Driver.SetUp(ctx, containers); err != nil {
+	if err := b.driver.SetUp(ctx, containers); err != nil {
 		return annotateAwsError(err)
 	}
 
-	if b.CustomDomain == "" {
+	if b.customDomain == "" {
 		domain, err := b.GetDelegateSubdomainZone(ctx)
 		if err != nil {
 			// return err; FIXME: ignore this error for now
 		} else {
-			b.CustomDomain = strings.ToLower(domain.Zone) // HACK: this should be DnsSafe
+			b.customDomain = b.getProjectDomain(domain.Zone)
 			b.shouldDelegateSubdomain = true
 		}
 	}
@@ -186,7 +185,7 @@ func (b *ByocAws) Deploy(ctx context.Context, req *defangv1.DeployRequest) (*def
 		payloadString = base64.StdEncoding.EncodeToString(data)
 		// TODO: consider making this a proper Data URL: "data:application/protobuf;base64,abcd…"
 	} else {
-		url, err := b.Driver.CreateUploadURL(ctx, etag)
+		url, err := b.driver.CreateUploadURL(ctx, etag)
 		if err != nil {
 			return nil, err
 		}
@@ -222,7 +221,7 @@ func (b *ByocAws) Deploy(ctx context.Context, req *defangv1.DeployRequest) (*def
 }
 
 func (b ByocAws) findZone(ctx context.Context, domain, role string) (string, error) {
-	cfg, err := b.Driver.LoadConfig(ctx)
+	cfg, err := b.driver.LoadConfig(ctx)
 	if err != nil {
 		return "", annotateAwsError(err)
 	}
@@ -253,11 +252,11 @@ func (b ByocAws) findZone(ctx context.Context, domain, role string) (string, err
 }
 
 func (b ByocAws) delegateSubdomain(ctx context.Context) (string, error) {
-	if b.CustomDomain == "" {
+	if b.customDomain == "" {
 		return "", errors.New("custom domain not set")
 	}
-	domain := b.CustomDomain
-	cfg, err := b.Driver.LoadConfig(ctx)
+	domain := b.customDomain
+	cfg, err := b.driver.LoadConfig(ctx)
 	if err != nil {
 		return "", annotateAwsError(err)
 	}
@@ -296,7 +295,7 @@ func (b ByocAws) WhoAmI(ctx context.Context) (*defangv1.WhoAmIResponse, error) {
 	}
 
 	// Use STS to get the account ID
-	cfg, err := b.Driver.LoadConfig(ctx)
+	cfg, err := b.driver.LoadConfig(ctx)
 	if err != nil {
 		return nil, annotateAwsError(err)
 	}
@@ -305,7 +304,7 @@ func (b ByocAws) WhoAmI(ctx context.Context) (*defangv1.WhoAmIResponse, error) {
 		return nil, annotateAwsError(err)
 	}
 	return &defangv1.WhoAmIResponse{
-		Tenant:  b.TenantID,
+		Tenant:  b.tenantID,
 		Region:  cfg.Region,
 		Account: *identity.Account,
 	}, nil
@@ -330,16 +329,16 @@ func (b ByocAws) Get(ctx context.Context, s *defangv1.ServiceID) (*defangv1.Serv
 }
 
 func (b *ByocAws) environment() map[string]string {
-	region := b.Driver.Region // TODO: this should be the destination region, not the CD region; make customizable
+	region := b.driver.Region // TODO: this should be the destination region, not the CD region; make customizable
 	return map[string]string{
 		// "AWS_REGION":               region.String(), should be set by ECS (because of CD task role)
 		"DEFANG_PREFIX":              DefangPrefix,
 		"DEFANG_DEBUG":               os.Getenv("DEFANG_DEBUG"), // TODO: use the global DoDebug flag
-		"DEFANG_ORG":                 b.TenantID,
-		"DOMAIN":                     b.CustomDomain,
+		"DEFANG_ORG":                 b.tenantID,
+		"DOMAIN":                     b.customDomain,
 		"PRIVATE_DOMAIN":             b.privateDomain,
 		"PROJECT":                    b.pulumiProject,
-		"PULUMI_BACKEND_URL":         fmt.Sprintf(`s3://%s?region=%s&awssdk=v2`, b.Driver.BucketName, region), // TODO: add a way to override bucket
+		"PULUMI_BACKEND_URL":         fmt.Sprintf(`s3://%s?region=%s&awssdk=v2`, b.driver.BucketName, region), // TODO: add a way to override bucket
 		"PULUMI_CONFIG_PASSPHRASE":   pkg.Getenv("PULUMI_CONFIG_PASSPHRASE", "asdf"),                          // TODO: make customizable
 		"STACK":                      b.pulumiStack,
 		"NPM_CONFIG_UPDATE_NOTIFIER": "false",
@@ -349,7 +348,7 @@ func (b *ByocAws) environment() map[string]string {
 
 func (b *ByocAws) runCdCommand(ctx context.Context, cmd ...string) (ecs.TaskArn, error) {
 	env := b.environment()
-	return b.Driver.Run(ctx, env, cmd...)
+	return b.driver.Run(ctx, env, cmd...)
 }
 
 func (b *ByocAws) Delete(ctx context.Context, req *defangv1.DeleteRequest) (*defangv1.DeleteResponse, error) {
@@ -385,7 +384,7 @@ func (b *ByocAws) getClusterNames() []string {
 
 func (b ByocAws) GetServices(ctx context.Context) (*defangv1.ListServicesResponse, error) {
 	var maxResults int32 = 100 // the maximum allowed by AWS
-	cfg, err := b.Driver.LoadConfig(ctx)
+	cfg, err := b.driver.LoadConfig(ctx)
 	if err != nil {
 		return nil, annotateAwsError(err)
 	}
@@ -457,13 +456,13 @@ func (b ByocAws) PutSecret(ctx context.Context, secret *defangv1.SecretValue) er
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid secret name; must be alphanumeric or _, cannot start with a number: %q", secret.Name))
 	}
 	fqn := b.getSecretID(secret.Name)
-	err := b.Driver.PutSecret(ctx, fqn, secret.Value)
+	err := b.driver.PutSecret(ctx, fqn, secret.Value)
 	return annotateAwsError(err)
 }
 
 func (b ByocAws) ListSecrets(ctx context.Context) (*defangv1.Secrets, error) {
 	prefix := b.getSecretID("")
-	awsSecrets, err := b.Driver.ListSecretsByPrefix(ctx, prefix)
+	awsSecrets, err := b.driver.ListSecretsByPrefix(ctx, prefix)
 	if err != nil {
 		return nil, err
 	}
@@ -479,7 +478,7 @@ func (b *ByocAws) CreateUploadURL(ctx context.Context, req *defangv1.UploadURLRe
 		return nil, err
 	}
 
-	url, err := b.Driver.CreateUploadURL(ctx, req.Digest)
+	url, err := b.driver.CreateUploadURL(ctx, req.Digest)
 	if err != nil {
 		return nil, err
 	}
@@ -506,14 +505,14 @@ func (b *ByocAws) Tail(ctx context.Context, req *defangv1.TailRequest) (client.S
 	var eventStream ecs.EventStream
 	if etag != "" && !pkg.IsValidRandomID(etag) {
 		// Assume "etag" is a task ID
-		eventStream, err = b.Driver.TailTaskID(ctx, etag)
-		taskArn, _ = b.Driver.GetTaskArn(etag)
+		eventStream, err = b.driver.TailTaskID(ctx, etag)
+		taskArn, _ = b.driver.GetTaskArn(etag)
 		etag = "" // no need to filter by etag
 	} else {
 		// Tail CD, kaniko, and all services
-		kanikoTail := ecs.LogGroupInput{LogGroupARN: b.Driver.MakeARN("logs", "log-group:"+b.stackDir("builds"))} // must match logic in ecs/common.ts
-		servicesTail := ecs.LogGroupInput{LogGroupARN: b.Driver.MakeARN("logs", "log-group:"+b.stackDir("logs"))} // must match logic in ecs/common.ts
-		cdTail := ecs.LogGroupInput{LogGroupARN: b.Driver.LogGroupARN}
+		kanikoTail := ecs.LogGroupInput{LogGroupARN: b.driver.MakeARN("logs", "log-group:"+b.stackDir("builds"))} // must match logic in ecs/common.ts
+		servicesTail := ecs.LogGroupInput{LogGroupARN: b.driver.MakeARN("logs", "log-group:"+b.stackDir("logs"))} // must match logic in ecs/common.ts
+		cdTail := ecs.LogGroupInput{LogGroupARN: b.driver.LogGroupARN}
 		taskArn = b.cdTasks[etag]
 		if taskArn != nil {
 			// Only tail the logstreams for the CD task
@@ -575,11 +574,16 @@ func (b ByocAws) update(ctx context.Context, service *defangv1.Service) (*defang
 
 	hasHost := false
 	hasIngress := false
-	fqn := service.Name //newQualifiedName(b.TenantID, service.Name)
-	for _, port := range service.Ports {
-		hasIngress = hasIngress || port.Mode == defangv1.Mode_INGRESS
-		hasHost = hasHost || port.Mode == defangv1.Mode_HOST
-		si.Endpoints = append(si.Endpoints, b.GetEndpoint(fqn, port))
+	fqn := service.Name
+	if service.StaticFiles == "" {
+		for _, port := range service.Ports {
+			hasIngress = hasIngress || port.Mode == defangv1.Mode_INGRESS
+			hasHost = hasHost || port.Mode == defangv1.Mode_HOST
+			si.Endpoints = append(si.Endpoints, b.GetEndpoint(fqn, port))
+		}
+	} else {
+		si.PublicFqdn = b.GetPublicFqdn(fqn)
+		si.Endpoints = append(si.Endpoints, si.PublicFqdn)
 	}
 	if hasIngress {
 		si.LbIps = b.privateLbIps // only set LB IPs if there are ingress ports
@@ -591,7 +595,7 @@ func (b ByocAws) update(ctx context.Context, service *defangv1.Service) (*defang
 
 	var warning Warning
 	if service.Domainname != "" {
-		if !hasIngress {
+		if !hasIngress && service.StaticFiles == "" {
 			return nil, errors.New("domainname requires at least one ingress port") // retryable CodeFailedPrecondition
 		}
 		// Do a DNS lookup for Domainname and confirm it's indeed a CNAME to the service's public FQDN
@@ -601,13 +605,13 @@ func (b ByocAws) update(ctx context.Context, service *defangv1.Service) (*defang
 			if err != nil {
 				return nil, err
 			}
-			if zoneId != "" {
-				si.ZoneId = zoneId
-			} else {
+			if zoneId == "" {
 				si.UseAcmeCert = true
 				// TODO: We should add link to documentation on how the acme cert workflow works
 				// TODO: Should we make this the default behavior or require the user to set a flag?
 				warning = WarningError(fmt.Sprintf("CNAME %q does not point to %q and no route53 zone managing domain was found, a let's encrypt cert will be used on first visit to the http end point", service.Domainname, si.PublicFqdn))
+			} else {
+				si.ZoneId = zoneId
 			}
 		}
 	}
@@ -623,7 +627,7 @@ func (b ByocAws) update(ctx context.Context, service *defangv1.Service) (*defang
 // This function was copied from Fabric controller and slightly modified to work with BYOC
 func (b ByocAws) checkForMissingSecrets(ctx context.Context, secrets []*defangv1.Secret) (*defangv1.Secret, error) {
 	prefix := b.getSecretID("")
-	sorted, err := b.Driver.ListSecretsByPrefix(ctx, prefix)
+	sorted, err := b.driver.ListSecretsByPrefix(ctx, prefix)
 	if err != nil {
 		return nil, err
 	}
@@ -643,46 +647,51 @@ type qualifiedName = string // legacy
 
 // This function was copied from Fabric controller and slightly modified to work with BYOC
 func (b ByocAws) GetEndpoint(fqn qualifiedName, port *defangv1.Port) string {
-	safeFqn := dnsSafe(fqn)
+	safeFqn := dnsSafeLabel(fqn)
 	if port.Mode == defangv1.Mode_HOST {
 		return fmt.Sprintf("%s.%s:%d", safeFqn, b.privateDomain, port.Target)
 	} else {
-		if b.CustomDomain == "" {
+		if b.customDomain == "" {
 			return ":443" // placeholder for the public ALB/distribution
 		}
-		return fmt.Sprintf("%s--%d.%s", safeFqn, port.Target, b.getProjectDomain(b.CustomDomain))
+		return fmt.Sprintf("%s--%d.%s", safeFqn, port.Target, b.customDomain)
 	}
 }
 
 // This function was copied from Fabric controller and slightly modified to work with BYOC
 func (b ByocAws) GetPublicFqdn(fqn qualifiedName) string {
-	safeFqn := dnsSafe(fqn)
-	if b.CustomDomain == "" {
+	if b.customDomain == "" {
 		return "" //b.fqdn
 	}
-	return fmt.Sprintf("%s.%s", safeFqn, b.getProjectDomain(b.CustomDomain))
+	safeFqn := dnsSafeLabel(fqn)
+	return fmt.Sprintf("%s.%s", safeFqn, b.customDomain)
 }
 
 // This function was copied from Fabric controller and slightly modified to work with BYOC
 func (b ByocAws) GetPrivateFqdn(fqn qualifiedName) string {
-	safeFqn := dnsSafe(fqn)
+	safeFqn := dnsSafeLabel(fqn)
 	return fmt.Sprintf("%s.%s", safeFqn, b.privateDomain)
 }
 
-func (b ByocAws) getProjectDomain(domain string) string {
-	if strings.EqualFold(b.pulumiProject, string(b.TenantID)) {
-		return domain
+func (b ByocAws) getProjectDomain(zone string) string {
+	projectLabel := dnsSafeLabel(b.pulumiProject)
+	if projectLabel == dnsSafeLabel(string(b.tenantID)) {
+		return dnsSafe(zone) // the zone will already have the tenant ID
 	}
-	return dnsSafe(b.pulumiProject) + "." + domain
+	return projectLabel + "." + dnsSafe(zone)
 }
 
 // This function was copied from Fabric controller and slightly modified to work with BYOC
-func dnsSafe(fqn qualifiedName) string {
-	return strings.ReplaceAll(strings.ToLower(string(fqn)), ".", "-")
+func dnsSafeLabel(fqn qualifiedName) string {
+	return strings.ReplaceAll(dnsSafe(string(fqn)), ".", "-")
+}
+
+func dnsSafe(fqdn string) string {
+	return strings.ToLower(fqdn)
 }
 
 func (b *ByocAws) TearDown(ctx context.Context) error {
-	return b.Driver.TearDown(ctx)
+	return b.driver.TearDown(ctx)
 }
 
 func (b *ByocAws) BootstrapCommand(ctx context.Context, command string) (string, error) {
@@ -705,7 +714,7 @@ func (b *ByocAws) DeleteSecrets(ctx context.Context, secrets *defangv1.Secrets) 
 	for i, name := range secrets.Names {
 		ids[i] = b.getSecretID(name)
 	}
-	if err := b.Driver.DeleteSecrets(ctx, ids...); err != nil {
+	if err := b.driver.DeleteSecrets(ctx, ids...); err != nil {
 		return annotateAwsError(err)
 	}
 	return nil
@@ -719,14 +728,14 @@ func (b *ByocAws) BootstrapList(ctx context.Context) error {
 	if err := b.setUp(ctx); err != nil {
 		return err
 	}
-	cfg, err := b.Driver.LoadConfig(ctx)
+	cfg, err := b.driver.LoadConfig(ctx)
 	if err != nil {
 		return annotateAwsError(err)
 	}
 	prefix := `.pulumi/stacks/` // TODO: should we filter on `projectName`?
 	s3client := s3.NewFromConfig(cfg)
 	out, err := s3client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-		Bucket: &b.Driver.BucketName,
+		Bucket: &b.driver.BucketName,
 		Prefix: &prefix,
 	})
 	if err != nil {
@@ -767,126 +776,4 @@ func annotateAwsError(err error) error {
 		return connect.NewError(connect.CodeNotFound, err)
 	}
 	return err
-}
-
-// byocServerStream is a wrapper around awsecs.EventStream that implements connect-like ServerStream
-type byocServerStream struct {
-	cancelTaskCh func()
-	err          error
-	errCh        <-chan error
-	etag         string
-	response     *defangv1.TailResponse
-	service      string
-	stream       ecs.EventStream
-	taskCh       <-chan error
-}
-
-var _ client.ServerStream[defangv1.TailResponse] = (*byocServerStream)(nil)
-
-func (bs *byocServerStream) Close() error {
-	if bs.cancelTaskCh != nil {
-		bs.cancelTaskCh()
-	}
-	return bs.stream.Close()
-}
-
-func (bs *byocServerStream) Err() error {
-	if bs.err == io.EOF {
-		return nil // same as the original gRPC/connect server stream
-	}
-	return annotateAwsError(bs.err)
-}
-
-func (bs *byocServerStream) Msg() *defangv1.TailResponse {
-	return bs.response
-}
-
-type hasErrCh interface {
-	Errs() <-chan error
-}
-
-func (bs *byocServerStream) Receive() bool {
-	select {
-	case e := <-bs.stream.Events(): // blocking
-		events, err := ecs.GetLogEvents(e)
-		if err != nil {
-			bs.err = err
-			return false
-		}
-		bs.response = &defangv1.TailResponse{}
-		if len(events) == 0 {
-			// The original gRPC/connect server stream would never send an empty response.
-			// We could loop around the select, but returning an empty response updates the spinner.
-			return true
-		}
-		var record logs.FirelensMessage
-		parseFirelensRecords := false
-		// Get the Etag/Host/Service from the first event (should be the same for all events in this batch)
-		event := events[0]
-		if parts := strings.Split(*event.LogStreamName, "/"); len(parts) == 3 {
-			if strings.Contains(*event.LogGroupIdentifier, ":"+CdTaskPrefix) {
-				// These events are from the CD task: "crun/main/taskID" stream; we should detect stdout/stderr
-				bs.response.Etag = bs.etag // pass the etag filter below, but we already filtered the tail by taskID
-				bs.response.Host = "pulumi"
-				bs.response.Service = "cd"
-			} else {
-				// These events are from an awslogs service task: "tenant/service_etag/taskID" stream
-				bs.response.Host = parts[2] // TODO: figure out actual hostname/IP
-				parts = strings.Split(parts[1], "_")
-				if len(parts) != 2 || !pkg.IsValidRandomID(parts[1]) {
-					// skip, ignore sidecar logs (like route53-sidecar or fluentbit)
-					return true
-				}
-				service, etag := parts[0], parts[1]
-				bs.response.Etag = etag
-				bs.response.Service = service
-			}
-		} else if strings.Contains(*event.LogStreamName, "-firelens-") {
-			// These events are from the Firelens sidecar; try to parse the JSON
-			if err := json.Unmarshal([]byte(*event.Message), &record); err == nil {
-				bs.response.Etag = record.Etag
-				bs.response.Host = record.Host             // TODO: use "kaniko" for kaniko logs
-				bs.response.Service = record.ContainerName // TODO: could be service_etag
-				parseFirelensRecords = true
-			}
-		}
-		if bs.etag != "" && bs.etag != bs.response.Etag {
-			return true // TODO: filter these out using the AWS StartLiveTail API
-		}
-		if bs.service != "" && bs.service != bs.response.Service {
-			return true // TODO: filter these out using the AWS StartLiveTail API
-		}
-		entries := make([]*defangv1.LogEntry, len(events))
-		for i, event := range events {
-			stderr := false //  TODO: detect somehow from source
-			message := *event.Message
-			if parseFirelensRecords {
-				if err := json.Unmarshal([]byte(message), &record); err == nil {
-					message = record.Log
-					if record.ContainerName == "kaniko" {
-						stderr = logs.IsLogrusError(message)
-					} else {
-						stderr = record.Source == logs.SourceStderr
-					}
-				}
-			} else if bs.response.Service == "cd" && strings.HasPrefix(message, " ** ") {
-				stderr = true
-			}
-			entries[i] = &defangv1.LogEntry{
-				Message:   message,
-				Stderr:    stderr,
-				Timestamp: timestamppb.New(time.UnixMilli(*event.Timestamp)),
-			}
-		}
-		bs.response.Entries = entries
-		return true
-
-	case err := <-bs.errCh: // blocking (if not nil)
-		bs.err = err
-		return false
-
-	case err := <-bs.taskCh: // blocking (if not nil)
-		bs.err = err
-		return false // TODO: make sure we got all the logs from the task
-	}
 }

--- a/src/pkg/cli/client/byoc/clouds/byoc_test.go
+++ b/src/pkg/cli/client/byoc/clouds/byoc_test.go
@@ -1,43 +1,42 @@
-package byoc
+package clouds
 
 import (
-	"github.com/defang-io/defang/src/pkg/cli/client/byoc/clouds"
 	"testing"
 
 	"github.com/defang-io/defang/src/pkg/types"
-	v1 "github.com/defang-io/defang/src/protos/io/defang/v1"
+	defangv1 "github.com/defang-io/defang/src/protos/io/defang/v1"
 )
 
 func TestDomainMultipleProjectSupport(t *testing.T) {
-	port80 := &v1.Port{Mode: v1.Mode_INGRESS, Target: 80}
-	port8080 := &v1.Port{Mode: v1.Mode_INGRESS, Target: 8080}
-	hostModePort := &v1.Port{Mode: v1.Mode_HOST, Target: 80}
+	port80 := &defangv1.Port{Mode: defangv1.Mode_INGRESS, Target: 80}
+	port8080 := &defangv1.Port{Mode: defangv1.Mode_INGRESS, Target: 8080}
+	hostModePort := &defangv1.Port{Mode: defangv1.Mode_HOST, Target: 80}
 	tests := []struct {
 		ProjectName string
 		TenantID    types.TenantID
 		Fqn         string
-		Port        *v1.Port
+		Port        *defangv1.Port
 		EndPoint    string
 		PublicFqdn  string
 		PrivateFqdn string
 	}{
-		{"", "tenant1", "web", port80, "web--80.example.com", "web.example.com", "web.internal"},
-		{"", "tenant1", "web", hostModePort, "web.internal:80", "web.example.com", "web.internal"},
+		{"", "tenant1", "web", port80, "web--80.example.com", "web.example.com", "web.tenant1.internal"},
+		{"", "tenant1", "web", hostModePort, "web.tenant1.internal:80", "web.example.com", "web.tenant1.internal"},
 		{"project1", "tenant1", "web", port80, "web--80.project1.example.com", "web.project1.example.com", "web.project1.internal"},
 		{"Project1", "tenant1", "web", port80, "web--80.project1.example.com", "web.project1.example.com", "web.project1.internal"},
 		{"project1", "tenant1", "web", hostModePort, "web.project1.internal:80", "web.project1.example.com", "web.project1.internal"},
 		{"project1", "tenant1", "api", port8080, "api--8080.project1.example.com", "api.project1.example.com", "api.project1.internal"},
-		{"tenant1", "tenant1", "web", port80, "web--80.example.com", "web.example.com", "web.internal"},
-		{"tenant1", "tenant1", "web", hostModePort, "web.internal:80", "web.example.com", "web.internal"},
+		{"tenant1", "tenant1", "web", port80, "web--80.example.com", "web.example.com", "web.tenant1.internal"},
+		{"tenant1", "tenant1", "web", hostModePort, "web.tenant1.internal:80", "web.example.com", "web.tenant1.internal"},
 		{"Project1", "tenant1", "web", port80, "web--80.project1.example.com", "web.project1.example.com", "web.project1.internal"},
 		{"Tenant2", "tenant1", "web", port80, "web--80.tenant2.example.com", "web.tenant2.example.com", "web.tenant2.internal"},
-		{"tenant1", "tenAnt1", "web", port80, "web--80.example.com", "web.example.com", "web.internal"},
+		{"tenant1", "tenAnt1", "web", port80, "web--80.example.com", "web.example.com", "web.tenant1.internal"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.ProjectName+","+string(tt.TenantID), func(t *testing.T) {
-			b := clouds.NewByocAWS(tt.TenantID, tt.ProjectName, nil)
-			b.CustomDomain = "example.com"
+			b := NewByocAWS(tt.TenantID, tt.ProjectName, nil)
+			b.customDomain = b.getProjectDomain("example.com")
 
 			endpoint := b.GetEndpoint(tt.Fqn, tt.Port)
 			if endpoint != tt.EndPoint {

--- a/src/pkg/cli/client/byoc/clouds/stream.go
+++ b/src/pkg/cli/client/byoc/clouds/stream.go
@@ -1,0 +1,137 @@
+package clouds
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/defang-io/defang/src/pkg"
+	"github.com/defang-io/defang/src/pkg/cli/client"
+	"github.com/defang-io/defang/src/pkg/clouds/aws/ecs"
+	"github.com/defang-io/defang/src/pkg/logs"
+	defangv1 "github.com/defang-io/defang/src/protos/io/defang/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// byocServerStream is a wrapper around awsecs.EventStream that implements connect-like ServerStream
+type byocServerStream struct {
+	cancelTaskCh func()
+	err          error
+	errCh        <-chan error
+	etag         string
+	response     *defangv1.TailResponse
+	service      string
+	stream       ecs.EventStream
+	taskCh       <-chan error
+}
+
+var _ client.ServerStream[defangv1.TailResponse] = (*byocServerStream)(nil)
+
+func (bs *byocServerStream) Close() error {
+	if bs.cancelTaskCh != nil {
+		bs.cancelTaskCh()
+	}
+	return bs.stream.Close()
+}
+
+func (bs *byocServerStream) Err() error {
+	if bs.err == io.EOF {
+		return nil // same as the original gRPC/connect server stream
+	}
+	return annotateAwsError(bs.err)
+}
+
+func (bs *byocServerStream) Msg() *defangv1.TailResponse {
+	return bs.response
+}
+
+type hasErrCh interface {
+	Errs() <-chan error
+}
+
+func (bs *byocServerStream) Receive() bool {
+	select {
+	case e := <-bs.stream.Events(): // blocking
+		events, err := ecs.GetLogEvents(e)
+		if err != nil {
+			bs.err = err
+			return false
+		}
+		bs.response = &defangv1.TailResponse{}
+		if len(events) == 0 {
+			// The original gRPC/connect server stream would never send an empty response.
+			// We could loop around the select, but returning an empty response updates the spinner.
+			return true
+		}
+		var record logs.FirelensMessage
+		parseFirelensRecords := false
+		// Get the Etag/Host/Service from the first event (should be the same for all events in this batch)
+		event := events[0]
+		if parts := strings.Split(*event.LogStreamName, "/"); len(parts) == 3 {
+			if strings.Contains(*event.LogGroupIdentifier, ":"+CdTaskPrefix) {
+				// These events are from the CD task: "crun/main/taskID" stream; we should detect stdout/stderr
+				bs.response.Etag = bs.etag // pass the etag filter below, but we already filtered the tail by taskID
+				bs.response.Host = "pulumi"
+				bs.response.Service = "cd"
+			} else {
+				// These events are from an awslogs service task: "tenant/service_etag/taskID" stream
+				bs.response.Host = parts[2] // TODO: figure out actual hostname/IP
+				parts = strings.Split(parts[1], "_")
+				if len(parts) != 2 || !pkg.IsValidRandomID(parts[1]) {
+					// skip, ignore sidecar logs (like route53-sidecar or fluentbit)
+					return true
+				}
+				service, etag := parts[0], parts[1]
+				bs.response.Etag = etag
+				bs.response.Service = service
+			}
+		} else if strings.Contains(*event.LogStreamName, "-firelens-") {
+			// These events are from the Firelens sidecar; try to parse the JSON
+			if err := json.Unmarshal([]byte(*event.Message), &record); err == nil {
+				bs.response.Etag = record.Etag
+				bs.response.Host = record.Host             // TODO: use "kaniko" for kaniko logs
+				bs.response.Service = record.ContainerName // TODO: could be service_etag
+				parseFirelensRecords = true
+			}
+		}
+		if bs.etag != "" && bs.etag != bs.response.Etag {
+			return true // TODO: filter these out using the AWS StartLiveTail API
+		}
+		if bs.service != "" && bs.service != bs.response.Service {
+			return true // TODO: filter these out using the AWS StartLiveTail API
+		}
+		entries := make([]*defangv1.LogEntry, len(events))
+		for i, event := range events {
+			stderr := false //  TODO: detect somehow from source
+			message := *event.Message
+			if parseFirelensRecords {
+				if err := json.Unmarshal([]byte(message), &record); err == nil {
+					message = record.Log
+					if record.ContainerName == "kaniko" {
+						stderr = logs.IsLogrusError(message)
+					} else {
+						stderr = record.Source == logs.SourceStderr
+					}
+				}
+			} else if bs.response.Service == "cd" && strings.HasPrefix(message, " ** ") {
+				stderr = true
+			}
+			entries[i] = &defangv1.LogEntry{
+				Message:   message,
+				Stderr:    stderr,
+				Timestamp: timestamppb.New(time.UnixMilli(*event.Timestamp)),
+			}
+		}
+		bs.response.Entries = entries
+		return true
+
+	case err := <-bs.errCh: // blocking (if not nil)
+		bs.err = err
+		return false // abort on first error?
+
+	case err := <-bs.taskCh: // blocking (if not nil)
+		bs.err = err
+		return false // TODO: make sure we got all the logs from the task
+	}
+}

--- a/src/protos/io/defang/v1/fabric.pb.go
+++ b/src/protos/io/defang/v1/fabric.pb.go
@@ -1997,8 +1997,8 @@ type Service struct {
 	Command     []string          `protobuf:"bytes,11,rep,name=command,proto3" json:"command,omitempty"`
 	Domainname  string            `protobuf:"bytes,12,opt,name=domainname,proto3" json:"domainname,omitempty"`
 	Init        bool              `protobuf:"varint,13,opt,name=init,proto3" json:"init,omitempty"`
-	DnsRole     string            `protobuf:"bytes,14,opt,name=dns_role,json=dnsRole,proto3" json:"dns_role,omitempty"`             // role arn used to access route53 to create dns records; TODO: not part of spec
-	StaticFiles string            `protobuf:"bytes,15,opt,name=static_files,json=staticFiles,proto3" json:"static_files,omitempty"` // folder with static files to serve; TODO: not part of spec
+	DnsRole     string            `protobuf:"bytes,14,opt,name=dns_role,json=dnsRole,proto3" json:"dns_role,omitempty"`             // x-defang-dns-role: role arn used to access route53 to create dns records; TODO: not part of spec
+	StaticFiles string            `protobuf:"bytes,15,opt,name=static_files,json=staticFiles,proto3" json:"static_files,omitempty"` // x-defang-static-files: folder with static files to serve; TODO: not part of spec
 }
 
 func (x *Service) Reset() {

--- a/src/protos/io/defang/v1/fabric.proto
+++ b/src/protos/io/defang/v1/fabric.proto
@@ -306,8 +306,8 @@ message Service {
   repeated string command = 11;
   string domainname = 12;
   bool init = 13;
-  string dns_role = 14; // role arn used to access route53 to create dns records; TODO: not part of spec
-  string static_files = 15; // folder with static files to serve; TODO: not part of spec
+  string dns_role = 14; // x-defang-dns-role: role arn used to access route53 to create dns records; TODO: not part of spec
+  string static_files = 15; // x-defang-static-files: folder with static files to serve; TODO: not part of spec
 }
 
 message Event {


### PR DESCRIPTION
This avoids multiple route53 zones called `internal` which are impossible to tell apart.

@kt5356 this PR also moves the BYOC test files into the clouds folder. In fact, those files are specific for the AWS implementation, so should probably be in its own aws package.

Fixes https://github.com/defang-io/defang-mvp/issues/555