### PR TITLE
move colorize.go to term package

### DIFF
--- a/src/cmd/cli/main.go
+++ b/src/cmd/cli/main.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 
 	"github.com/defang-io/defang/src/cmd/cli/command"
-	"github.com/defang-io/defang/src/pkg/cli"
+	"github.com/defang-io/defang/src/pkg/term"
 )
 
 func main() {
@@ -18,7 +18,7 @@ func main() {
 	go func() {
 		<-sigs
 		signal.Stop(sigs)
-		cli.Debug("Received interrupt signal; cancelling...")
+		term.Debug("Received interrupt signal; cancelling...")
 		command.Track("User Interrupted")
 		command.FlushAllTracking()
 		cancel()

--- a/src/cmd/crun/main.go
+++ b/src/cmd/crun/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/defang-io/defang/src/pkg/cmd"
+	"github.com/defang-io/defang/src/pkg/term"
 	"github.com/spf13/pflag"
 )
 
@@ -65,7 +66,7 @@ func main() {
 
 	requireTaskID := func() string {
 		if pflag.NArg() != 2 {
-			cmd.Fatal(command + " requires a single task ID argument")
+			term.Fatal(command + " requires a single task ID argument")
 		}
 		return pflag.Arg(1)
 	}
@@ -78,14 +79,14 @@ func main() {
 		usage()
 	case "run", "r":
 		if runFlags.NArg() < 1 {
-			cmd.Fatal("run requires an image name (and optional arguments)")
+			term.Fatal("run requires an image name (and optional arguments)")
 		}
 
 		envMap := make(map[string]string)
 		// Apply env vars from files first, so they can be overridden by the command line
 		for _, envFile := range *envFiles {
 			if _, err := cmd.ParseEnvFile(envFile, envMap); err != nil {
-				cmd.Fatal(err)
+				term.Fatal(err)
 			}
 		}
 		// Apply env vars from the command line last, so they take precedence
@@ -114,15 +115,15 @@ func main() {
 		err = cmd.Logs(ctx, region, &taskID)
 	case "destroy", "teardown", "d":
 		if pflag.NArg() != 1 {
-			cmd.Fatal("destroy does not take any arguments")
+			term.Fatal("destroy does not take any arguments")
 		}
 		err = cmd.Destroy(ctx, region)
 	case "info", "i":
 		taskID := requireTaskID()
-		err = cmd.Info(ctx, region, &taskID)
+		err = cmd.PrintInfo(ctx, region, &taskID)
 	}
 
 	if err != nil {
-		cmd.Fatal(err)
+		term.Fatal(err)
 	}
 }

--- a/src/cmd/gendocs/main.go
+++ b/src/cmd/gendocs/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"log"
 	"os"
 
 	"github.com/defang-io/defang/src/cmd/cli/command"
+	"github.com/defang-io/defang/src/pkg/term"
 	"github.com/spf13/cobra/doc"
 )
 
@@ -22,6 +22,6 @@ func main() {
 
 	err := doc.GenMarkdownTree(command.RootCmd, docsPath)
 	if err != nil {
-		log.Fatal(err)
+		term.Fatal(err)
 	}
 }

--- a/src/pkg/cli/agree_tos.go
+++ b/src/pkg/cli/agree_tos.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/defang-io/defang/src/pkg/cli/client"
+	"github.com/defang-io/defang/src/pkg/term"
 )
 
 func InteractiveAgreeToS(ctx context.Context, client client.Client) error {
-	Println(Nop, "Our latest terms of service can be found at https://defang.io/terms-service.html")
+	term.Println(term.Nop, "Our latest terms of service can be found at https://defang.io/terms-service.html")
 
 	var agreeToS bool
 	err := survey.AskOne(&survey.Confirm{
@@ -34,6 +35,6 @@ func NonInteractiveAgreeToS(ctx context.Context, client client.Client) error {
 	if err := client.AgreeToS(ctx); err != nil {
 		return err
 	}
-	Info(" * You have agreed to the Defang terms of service")
+	term.Info(" * You have agreed to the Defang terms of service")
 	return nil
 }

--- a/src/pkg/cli/bootstrap.go
+++ b/src/pkg/cli/bootstrap.go
@@ -5,10 +5,11 @@ import (
 	"time"
 
 	"github.com/defang-io/defang/src/pkg/cli/client"
+	"github.com/defang-io/defang/src/pkg/term"
 )
 
 func BootstrapCommand(ctx context.Context, client client.Client, command string) error {
-	Debug(" - Running CD command", command)
+	term.Debug(" - Running CD command", command)
 	if DoDryRun {
 		return ErrDryRun
 	}
@@ -21,7 +22,7 @@ func BootstrapCommand(ctx context.Context, client client.Client, command string)
 }
 
 func BootstrapList(ctx context.Context, client client.Client) error {
-	Debug(" - Running CD list")
+	term.Debug(" - Running CD list")
 	if DoDryRun {
 		return ErrDryRun
 	}

--- a/src/pkg/cli/client/byoc/clouds/common.go
+++ b/src/pkg/cli/client/byoc/clouds/common.go
@@ -1,8 +1,9 @@
 package clouds
 
 import (
-	"github.com/defang-io/defang/src/pkg"
 	"strings"
+
+	"github.com/defang-io/defang/src/pkg"
 )
 
 const (

--- a/src/pkg/cli/common.go
+++ b/src/pkg/cli/common.go
@@ -11,10 +11,7 @@ import (
 )
 
 var (
-	DoVerbose   = false
-	DoDebug     = false
-	DoDryRun    = false
-	HadWarnings = false
+	DoDryRun = false
 
 	ErrDryRun = errors.New("dry run")
 )

--- a/src/pkg/cli/composeStart.go
+++ b/src/pkg/cli/composeStart.go
@@ -9,6 +9,7 @@ import (
 	compose "github.com/compose-spec/compose-go/v2/types"
 	"github.com/defang-io/defang/src/pkg/cli/client"
 	"github.com/defang-io/defang/src/pkg/cli/client/byoc/clouds"
+	"github.com/defang-io/defang/src/pkg/term"
 	defangv1 "github.com/defang-io/defang/src/protos/io/defang/v1"
 )
 
@@ -175,7 +176,7 @@ func ComposeStart(ctx context.Context, c client.Client, project *compose.Project
 	}
 
 	for _, service := range services {
-		Info(" * Deploying service", service.Name)
+		term.Info(" * Deploying service", service.Name)
 	}
 
 	resp, err := c.Deploy(ctx, &defangv1.DeployRequest{
@@ -184,13 +185,13 @@ func ComposeStart(ctx context.Context, c client.Client, project *compose.Project
 	var warnings clouds.Warnings
 	if errors.As(err, &warnings) {
 		if len(warnings) > 0 {
-			Warn(" !", warnings)
+			term.Warn(" !", warnings)
 		}
 	} else if err != nil {
 		return nil, err
 	}
 
-	if DoDebug {
+	if term.DoDebug {
 		for _, service := range resp.Services {
 			PrintObject(service.Service.Name, service)
 		}

--- a/src/pkg/cli/compose_test.go
+++ b/src/pkg/cli/compose_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/defang-io/defang/src/pkg/cli/client"
+	"github.com/defang-io/defang/src/pkg/term"
 	defangv1 "github.com/defang-io/defang/src/protos/io/defang/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -46,7 +47,7 @@ func TestNormalizeServiceName(t *testing.T) {
 
 func TestLoadCompose(t *testing.T) {
 	DoVerbose = true
-	DoDebug = true
+	term.DoDebug = true
 
 	t.Run("no project name defaults to tenantID", func(t *testing.T) {
 		p, err := LoadComposeWithProjectName("../../tests/noprojname/compose.yaml", "tenant-id")

--- a/src/pkg/cli/connect.go
+++ b/src/pkg/cli/connect.go
@@ -4,9 +4,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"github.com/defang-io/defang/src/pkg/cli/client/byoc/clouds"
 	"net"
 	"strings"
+
+	"github.com/defang-io/defang/src/pkg/cli/client/byoc/clouds"
+	"github.com/defang-io/defang/src/pkg/term"
 
 	"github.com/defang-io/defang/src/pkg/cli/client"
 	"github.com/defang-io/defang/src/pkg/types"
@@ -56,17 +58,17 @@ func Connect(cluster string) (*client.GrpcClient, types.TenantID) {
 	if tenant != types.DEFAULT_TENANT {
 		tenantId = tenant
 	}
-	Debug(" - Using tenant", tenantId, "for cluster", host)
+	term.Debug(" - Using tenant", tenantId, "for cluster", host)
 
 	return client.NewGrpcClient(host, accessToken), tenantId
 }
 
 func NewClient(cluster string, projectName string, provider client.Provider) client.Client {
-	Debug(" - Project", projectName)
+	term.Debug(" - Project", projectName)
 	defangClient, tenantId := Connect(cluster)
 
 	if provider == client.ProviderAWS {
-		Info(" # Using AWS provider") // HACK: # prevents errors when evaluating the shell completion script
+		term.Info(" # Using AWS provider") // HACK: # prevents errors when evaluating the shell completion script
 		byocClient := clouds.NewByocAWS(tenantId, projectName, defangClient)
 		return byocClient
 	}

--- a/src/pkg/cli/delete.go
+++ b/src/pkg/cli/delete.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	"github.com/defang-io/defang/src/pkg/cli/client"
+	"github.com/defang-io/defang/src/pkg/term"
 	defangv1 "github.com/defang-io/defang/src/protos/io/defang/v1"
 )
 
 // Deprecated: Use ComposeStop instead.
 func Delete(ctx context.Context, client client.Client, names ...string) (client.ETag, error) {
-	Debug(" - Deleting service", names)
+	term.Debug(" - Deleting service", names)
 
 	if DoDryRun {
 		return "", ErrDryRun

--- a/src/pkg/cli/generate.go
+++ b/src/pkg/cli/generate.go
@@ -6,12 +6,13 @@ import (
 	"os"
 
 	"github.com/defang-io/defang/src/pkg/cli/client"
+	"github.com/defang-io/defang/src/pkg/term"
 	defangv1 "github.com/defang-io/defang/src/protos/io/defang/v1"
 )
 
 func Generate(ctx context.Context, client client.Client, language string, description string) ([]string, error) {
 	if DoDryRun {
-		Warn(" ! Dry run, not generating files")
+		term.Warn(" ! Dry run, not generating files")
 		return nil, ErrDryRun
 	}
 
@@ -23,19 +24,19 @@ func Generate(ctx context.Context, client client.Client, language string, descri
 		return nil, err
 	}
 
-	if DoDebug {
+	if term.DoDebug {
 		// Print the files that were generated
 		for _, file := range response.Files {
-			Debug(file.Name + "\n```")
-			Debug(file.Content)
-			Debug("```")
-			Debug("")
-			Debug("")
+			term.Debug(file.Name + "\n```")
+			term.Debug(file.Content)
+			term.Debug("```")
+			term.Debug("")
+			term.Debug("")
 		}
 	}
 
 	// Write each file to disk
-	Info(" * Writing files to disk...")
+	term.Info(" * Writing files to disk...")
 	for _, file := range response.Files {
 		// Print the files that were generated
 		fmt.Println("   -", file.Name)

--- a/src/pkg/cli/login.go
+++ b/src/pkg/cli/login.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/defang-io/defang/src/pkg/cli/client"
 	"github.com/defang-io/defang/src/pkg/github"
+	"github.com/defang-io/defang/src/pkg/term"
 	defangv1 "github.com/defang-io/defang/src/protos/io/defang/v1"
 )
 
@@ -25,18 +26,18 @@ func GetExistingToken(fabric string) string {
 	if accessToken == "" {
 		tokenFile := getTokenFile(fabric)
 
-		Debug(" - Reading access token from file", tokenFile)
+		term.Debug(" - Reading access token from file", tokenFile)
 		all, _ := os.ReadFile(tokenFile)
 		accessToken = string(all)
 	} else {
-		Debug(" - Using access token from env DEFANG_ACCESS_TOKEN")
+		term.Debug(" - Using access token from env DEFANG_ACCESS_TOKEN")
 	}
 
 	return accessToken
 }
 
 func loginWithGitHub(ctx context.Context, client client.Client, gitHubClientId, fabric string) (string, error) {
-	Debug(" - Logging in to", fabric)
+	term.Debug(" - Logging in to", fabric)
 
 	code, err := github.StartAuthCodeFlow(ctx, gitHubClientId)
 	if err != nil {
@@ -49,7 +50,7 @@ func loginWithGitHub(ctx context.Context, client client.Client, gitHubClientId, 
 
 func saveAccessToken(fabric, at string) error {
 	tokenFile := getTokenFile(fabric)
-	Debug(" - Saving access token to", tokenFile)
+	term.Debug(" - Saving access token to", tokenFile)
 	os.MkdirAll(client.StateDir, 0700)
 	if err := os.WriteFile(tokenFile, []byte(at), 0600); err != nil {
 		return err
@@ -64,21 +65,21 @@ func InteractiveLogin(ctx context.Context, client client.Client, gitHubClientId,
 	}
 
 	tenant, host := SplitTenantHost(fabric)
-	Info(" * Successfully logged in to", host, "("+tenant.String()+" tenant)")
+	term.Info(" * Successfully logged in to", host, "("+tenant.String()+" tenant)")
 
 	if err := saveAccessToken(fabric, at); err != nil {
-		Warn(" ! Failed to save access token:", err)
+		term.Warn(" ! Failed to save access token:", err)
 	}
 	return nil
 }
 
 func NonInteractiveLogin(ctx context.Context, client client.Client, fabric string) error {
-	Debug(" - Non-interactive login using GitHub Actions id-token")
+	term.Debug(" - Non-interactive login using GitHub Actions id-token")
 	idToken, err := github.GetIdToken(ctx)
 	if err != nil {
 		return fmt.Errorf("non-interactive login failed: %w", err)
 	}
-	Debug(" - Got GitHub Actions id-token")
+	term.Debug(" - Got GitHub Actions id-token")
 	resp, err := client.Token(ctx, &defangv1.TokenRequest{
 		Assertion: idToken,
 		Scope:     []string{"admin", "read"},

--- a/src/pkg/cli/logout.go
+++ b/src/pkg/cli/logout.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/bufbuild/connect-go"
 	"github.com/defang-io/defang/src/pkg/cli/client"
+	"github.com/defang-io/defang/src/pkg/term"
 )
 
 func Logout(ctx context.Context, client client.Client) error {
-	Debug(" - Logging out")
+	term.Debug(" - Logging out")
 	err := client.RevokeToken(ctx)
 	// Ignore unauthenticated errors, since we're logging out anyway
 	if connect.CodeOf(err) != connect.CodeUnauthenticated {

--- a/src/pkg/cli/restart.go
+++ b/src/pkg/cli/restart.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	"github.com/defang-io/defang/src/pkg/cli/client"
+	"github.com/defang-io/defang/src/pkg/term"
 )
 
 func Restart(ctx context.Context, client client.Client, names ...string) error {
-	Debug(" - Restarting service", names)
+	term.Debug(" - Restarting service", names)
 
 	if DoDryRun {
 		return ErrDryRun

--- a/src/pkg/cli/secretsDelete.go
+++ b/src/pkg/cli/secretsDelete.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/defang-io/defang/src/pkg/cli/client"
+	"github.com/defang-io/defang/src/pkg/term"
 	defangv1 "github.com/defang-io/defang/src/protos/io/defang/v1"
 )
 
 func SecretsDelete(ctx context.Context, client client.Client, names ...string) error {
-	Debug(" - Deleting secret", names)
+	term.Debug(" - Deleting secret", names)
 
 	if DoDryRun {
 		return ErrDryRun

--- a/src/pkg/cli/secretsSet.go
+++ b/src/pkg/cli/secretsSet.go
@@ -5,11 +5,12 @@ import (
 	"errors"
 
 	"github.com/defang-io/defang/src/pkg/cli/client"
+	"github.com/defang-io/defang/src/pkg/term"
 	defangv1 "github.com/defang-io/defang/src/protos/io/defang/v1"
 )
 
 func SecretsSet(ctx context.Context, client client.Client, name string, value string) error {
-	Debug(" - Setting secret", name)
+	term.Debug(" - Setting secret", name)
 
 	if value == "" {
 		return errors.New("value cannot be empty") // FIXME: remove once we implement DeleteSecrets rpc

--- a/src/pkg/cli/sendMsg.go
+++ b/src/pkg/cli/sendMsg.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/defang-io/defang/src/pkg/cli/client"
+	"github.com/defang-io/defang/src/pkg/term"
 	defangv1 "github.com/defang-io/defang/src/protos/io/defang/v1"
 	"github.com/google/uuid"
 )
@@ -20,7 +21,7 @@ func SendMsg(ctx context.Context, client client.Client, subject, _type, id strin
 		id = uuid.NewString()
 	}
 
-	Debug(" - Sending message to", subject, "with type", _type, "and id", id)
+	term.Debug(" - Sending message to", subject, "with type", _type, "and id", id)
 
 	if DoDryRun {
 		return ErrDryRun

--- a/src/pkg/cli/token.go
+++ b/src/pkg/cli/token.go
@@ -8,6 +8,7 @@ import (
 	"github.com/defang-io/defang/src/pkg/cli/client"
 	"github.com/defang-io/defang/src/pkg/github"
 	"github.com/defang-io/defang/src/pkg/scope"
+	"github.com/defang-io/defang/src/pkg/term"
 	"github.com/defang-io/defang/src/pkg/types"
 	defangv1 "github.com/defang-io/defang/src/protos/io/defang/v1"
 )
@@ -27,7 +28,7 @@ func Token(ctx context.Context, client client.Client, clientId string, tenant ty
 		return err
 	}
 
-	Print(BrightCyan, "Scoped access token: ")
+	term.Print(term.BrightCyan, "Scoped access token: ")
 	fmt.Println(at)
 	return nil
 }
@@ -42,7 +43,7 @@ func exchangeCodeForToken(ctx context.Context, client client.Client, code string
 		scopes = append(scopes, s.String())
 	}
 
-	Debug(" - Generating token for tenant", tenant, "with scopes", scopes)
+	term.Debug(" - Generating token for tenant", tenant, "with scopes", scopes)
 
 	token, err := client.Token(ctx, &defangv1.TokenRequest{AuthCode: code, Tenant: string(tenant), Scope: scopes, ExpiresIn: uint32(dur.Seconds())})
 	if err != nil {

--- a/src/pkg/cli/whoami.go
+++ b/src/pkg/cli/whoami.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/defang-io/defang/src/pkg/cli/client"
+	"github.com/defang-io/defang/src/pkg/term"
 )
 
 func Whoami(ctx context.Context, client client.Client) error {
@@ -11,6 +12,6 @@ func Whoami(ctx context.Context, client client.Client) error {
 	if err != nil {
 		return err
 	}
-	Info(" * You are logged in to tenant", resp.Tenant, "in", resp.Account, "region", resp.Region)
+	term.Info(" * You are logged in to tenant", resp.Tenant, "in", resp.Account, "region", resp.Region)
 	return nil
 }

--- a/src/pkg/cmd/color.go
+++ b/src/pkg/cmd/color.go
@@ -1,17 +1,6 @@
 package cmd
 
-import (
-	"os"
-
-	"golang.org/x/term"
-)
-
-var (
-	termEnv    = os.Getenv("TERM")
-	isTerminal = term.IsTerminal(int(os.Stdout.Fd())) && termEnv != ""
-	_, noColor = os.LookupEnv("NO_COLOR") // per spec, the value doesn't matter
-	CanColor   = isTerminal && !noColor && termEnv != "dumb"
-)
+import "github.com/defang-io/defang/src/pkg/term"
 
 type Color string
 
@@ -25,14 +14,14 @@ const (
 func ParseColor(color string) Color {
 	switch color {
 	case "auto":
-		if CanColor {
+		if term.CanColor {
 			return ColorAlways
 		}
 		fallthrough
 	case "always", "never", "raw":
 		return Color(color)
 	default:
-		Fatal("invalid color option: " + color)
+		term.Fatal("invalid color option: " + color)
 		panic("unreachable")
 	}
 }

--- a/src/pkg/cmd/common.go
+++ b/src/pkg/cmd/common.go
@@ -1,20 +1,15 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
 
 	"github.com/defang-io/defang/src/pkg/clouds/aws"
+	"github.com/defang-io/defang/src/pkg/term"
 )
 
 type Region = aws.Region
-
-func Fatal(msg any) {
-	fmt.Println("Error:", msg) // TODO: color red
-	os.Exit(1)
-}
 
 func ParseMemory(memory string) uint64 {
 	i := strings.IndexAny(memory, "BKMGIbkmgi")
@@ -22,7 +17,7 @@ func ParseMemory(memory string) uint64 {
 	if i > 0 {
 		switch strings.ToUpper(memory[i:]) {
 		default:
-			Fatal("invalid suffix: " + memory)
+			term.Fatal("invalid suffix: " + memory)
 		case "G", "GIB":
 			memUnit = 1024 * 1024 * 1024
 		case "GB":
@@ -41,7 +36,7 @@ func ParseMemory(memory string) uint64 {
 	}
 	memoryB, err := strconv.ParseUint(memory, 10, 64)
 	if err != nil {
-		Fatal(err.Error())
+		term.Fatal(err.Error())
 	}
 	return memoryB * memUnit
 }

--- a/src/pkg/cmd/info.go
+++ b/src/pkg/cmd/info.go
@@ -7,7 +7,7 @@ import (
 	"github.com/defang-io/defang/src/pkg/types"
 )
 
-func Info(ctx context.Context, region Region, id types.TaskID) error {
+func PrintInfo(ctx context.Context, region Region, id types.TaskID) error {
 	driver, err := createDriver(region)
 	if err != nil {
 		return err


### PR DESCRIPTION
This way we can use the output functions (`term.Debug` etc.) from all packages without cyclic imports.