### PR TITLE
only trigger publish if the release build workflow completes successfully first

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,14 +1,14 @@
 # This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
-name: Defang CLI Package
+name: Defang NPM Package
 
+# This event will only trigger a workflow run if the workflow file is on the default branch.
 on:
-  release:
-    types: [created]
-  push:
-    tags:
-      - "v*"
+  workflow_run:
+    workflows: [Go package]
+    types: [completed]
+    branches: [main]
 
 env:
   DEFANG_CLI_RELEASE_VERSION: ${{ github.ref_name }}
@@ -18,11 +18,12 @@ env:
 jobs:
   publish-npm-binaries:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }} && startsWith(${{github.ref_name}}, 'v')
 
     defaults:
       run:
         shell: bash
-        working-directory: ./packaging/npm
+        working-directory: ./pkgs/npm
 
     steps:
       - name: Checkout tag


### PR DESCRIPTION
Updates so binary build workflow completes before we run the publish workflow. This workflow is not truly dependent on the "Go package" workflow but if that workflow does not succeed then there is no point in publishing a npm package.