### PR TITLE
simplify colorizer

### DIFF
--- a/src/cmd/cli/command/commands.go
+++ b/src/cmd/cli/command/commands.go
@@ -91,13 +91,13 @@ func Execute(ctx context.Context) error {
 	}
 
 	if hasTty && term.HadWarnings {
-		term.Println(term.Nop, "For help with warnings, check our FAQ at https://docs.defang.io/docs/faq")
+		fmt.Println("For help with warnings, check our FAQ at https://docs.defang.io/docs/faq")
 	}
 
 	if hasTty && !pkg.GetenvBool("DEFANG_HIDE_UPDATE") && rand.Intn(10) == 0 {
 		if latest, err := GetLatestVersion(ctx); err == nil && semver.Compare(GetCurrentVersion(), latest) < 0 {
 			term.Debug("Latest Version:", latest, "Current Version:", GetCurrentVersion())
-			term.Println(term.Nop, "A newer version of the CLI is available at https://github.com/defang-io/defang/releases/latest")
+			fmt.Println("A newer version of the CLI is available at https://github.com/defang-io/defang/releases/latest")
 			if rand.Intn(10) == 0 && !pkg.GetenvBool("DEFANG_HIDE_HINTS") {
 				fmt.Println("To silence these notices, do: export DEFANG_HIDE_UPDATE=1")
 			}
@@ -676,7 +676,7 @@ func printPlaygroundPortalServiceURLs(serviceInfos []*defangv1.ServiceInfo) {
 	if provider == cliClient.ProviderDefang {
 		term.Info(" * Monitor your services' status in the defang portal")
 		for _, serviceInfo := range serviceInfos {
-			term.Println(term.Nop, "   - ", SERVICE_PORTAL_URL+"/"+serviceInfo.Service.Name)
+			fmt.Println("   -", SERVICE_PORTAL_URL+"/"+serviceInfo.Service.Name)
 		}
 	}
 }

--- a/src/pkg/cli/agree_tos.go
+++ b/src/pkg/cli/agree_tos.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/defang-io/defang/src/pkg/cli/client"
@@ -12,7 +13,7 @@ import (
 var ErrTermsNotAgreed = errors.New("You must agree to the Defang terms of service to use this tool")
 
 func InteractiveAgreeToS(ctx context.Context, client client.Client) error {
-	term.Println(term.Nop, "Our latest terms of service can be found at https://defang.io/terms-service.html")
+	fmt.Println("Our latest terms of service can be found at https://defang.io/terms-service.html")
 
 	var agreeToS bool
 	err := survey.AskOne(&survey.Confirm{

--- a/src/pkg/cli/cert.go
+++ b/src/pkg/cli/cert.go
@@ -79,7 +79,7 @@ func triggerCertGeneration(ctx context.Context, domain string) {
 				case <-spinCtx.Done():
 					return
 				case <-ticker.C:
-					term.Print(term.Nop, spin.Next())
+					fmt.Print(spin.Next())
 				}
 			}
 		}()
@@ -111,7 +111,7 @@ func waitForTLS(ctx context.Context, domain string) error {
 				return nil
 			}
 			if doSpinner {
-				term.Print(term.Nop, spin.Next())
+				fmt.Print(spin.Next())
 			}
 		}
 	}
@@ -143,7 +143,7 @@ func waitForCNAME(ctx context.Context, domain, albDns string) error {
 					msgShown = true
 				}
 				if doSpinner {
-					term.Print(term.Nop, spin.Next())
+					fmt.Print(spin.Next())
 				}
 			} else {
 				return nil

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"regexp"
 	"strings"
@@ -140,7 +141,7 @@ func Tail(ctx context.Context, client client.Client, service, etag string, since
 					case 3: // Ctrl-C
 						cancel()
 					case 10, 13: // Enter or Return
-						term.Println(term.Nop, " ") // empty line, but overwrite the spinner
+						fmt.Println(" ") // empty line, but overwrite the spinner
 					case 'v', 'V':
 						verbose := !DoVerbose
 						DoVerbose = verbose
@@ -190,7 +191,7 @@ func Tail(ctx context.Context, client client.Client, service, etag string, since
 
 		// Show a spinner if we're not in raw mode and have a TTY
 		if doSpinner {
-			term.Print(term.Nop, spin.Next())
+			fmt.Print(spin.Next())
 		}
 
 		// HACK: skip noisy CI/CD logs (except errors)
@@ -215,7 +216,7 @@ func Tail(ctx context.Context, client client.Client, service, etag string, since
 				if e.Stderr {
 					out = term.Stderr
 				}
-				term.Fprintln(out, term.Nop, e.Message) // TODO: trim trailing newline because we're already printing one?
+				fmt.Fprintln(out, e.Message) // TODO: trim trailing newline because we're already printing one?
 				continue
 			}
 
@@ -247,7 +248,7 @@ func Tail(ctx context.Context, client client.Client, service, etag string, since
 						prefixLen += l
 					}
 				} else {
-					term.Print(term.Nop, strings.Repeat(" ", prefixLen))
+					fmt.Print(strings.Repeat(" ", prefixLen))
 				}
 				if term.CanColor {
 					if !strings.Contains(line, "\033[") {
@@ -257,7 +258,7 @@ func Tail(ctx context.Context, client client.Client, service, etag string, since
 				} else {
 					line = pkg.StripAnsi(line)
 				}
-				term.Println(term.Nop, line)
+				fmt.Println(line)
 			}
 		}
 	}

--- a/src/pkg/term/colorizer.go
+++ b/src/pkg/term/colorizer.go
@@ -21,12 +21,11 @@ var (
 type Color = termenv.ANSIColor
 
 const (
-	Nop        Color = -1
-	BrightCyan       = termenv.ANSIBrightCyan
-	InfoColor        = termenv.ANSIBrightMagenta
-	ErrorColor       = termenv.ANSIBrightRed
-	WarnColor        = termenv.ANSIBrightYellow
-	DebugColor       = termenv.ANSIBrightBlack // Gray
+	BrightCyan = termenv.ANSIBrightCyan
+	InfoColor  = termenv.ANSIBrightMagenta
+	ErrorColor = termenv.ANSIBrightRed
+	WarnColor  = termenv.ANSIBrightYellow
+	DebugColor = termenv.ANSIBrightBlack // Gray
 )
 
 // doColor returns true if the provided output's profile is not Ascii.
@@ -44,38 +43,35 @@ func ForceColor(color bool) {
 	}
 }
 
-func output(w *termenv.Output, c Color, msg string, addNewLine bool) (int, error) {
+func output(w *termenv.Output, c Color, msg string) (int, error) {
 	if len(msg) == 0 {
 		return 0, nil
 	}
-	if doColor(w) && c != Nop {
+	if doColor(w) {
 		w.WriteString(termenv.CSI + c.Sequence(false) + "m")
 		defer w.Reset()
 	}
-	if addNewLine && msg[len(msg)-1] != '\n' && msg[len(msg)-1] != '\r' {
-		msg += "\n"
+	return w.WriteString(msg)
+}
+
+func outputf(w *termenv.Output, c Color, format string, v ...any) (int, error) {
+	line := fmt.Sprintf(format, v...)
+	if len(line) == 0 || (line[len(line)-1] != '\n' && line[len(line)-1] != '\r') {
+		line += "\n" // add newline, like log.Printf
 	}
-	return fmt.Fprint(w, msg)
+	return output(w, c, line)
 }
 
 func Fprint(w *termenv.Output, c Color, v ...any) (int, error) {
-	return output(w, c, fmt.Sprint(v...), false)
+	return output(w, c, fmt.Sprint(v...))
 }
 
 func Fprintln(w *termenv.Output, c Color, v ...any) (int, error) {
-	return output(w, c, fmt.Sprintln(v...), false)
+	return output(w, c, fmt.Sprintln(v...))
 }
 
 func Fprintf(w *termenv.Output, c Color, format string, v ...any) (int, error) {
-	return output(w, c, fmt.Sprintf(format, v...), false)
-}
-
-func Flog(w *termenv.Output, c Color, v ...any) (int, error) {
-	return output(w, c, fmt.Sprintln(v...), true)
-}
-
-func Flogf(w *termenv.Output, c Color, format string, v ...any) (int, error) {
-	return output(w, c, fmt.Sprintf(format, v...), true)
+	return output(w, c, fmt.Sprintf(format, v...))
 }
 
 func Print(c Color, v ...any) (int, error) {
@@ -94,40 +90,40 @@ func Debug(v ...any) (int, error) {
 	if !DoDebug {
 		return 0, nil
 	}
-	return Flog(Stderr, DebugColor, v...)
+	return Fprintln(Stderr, DebugColor, v...)
 }
 
 func Debugf(format string, v ...any) (int, error) {
 	if !DoDebug {
 		return 0, nil
 	}
-	return Flogf(Stderr, DebugColor, format, v...)
+	return outputf(Stderr, DebugColor, format, v...)
 }
 
 func Info(v ...any) (int, error) {
-	return Flog(Stdout, InfoColor, v...)
+	return Fprintln(Stdout, InfoColor, v...)
 }
 
 func Infof(format string, v ...any) (int, error) {
-	return Flogf(Stdout, InfoColor, format, v...)
+	return outputf(Stdout, InfoColor, format, v...)
 }
 
 func Warn(v ...any) (int, error) {
 	HadWarnings = true
-	return Flog(Stderr, WarnColor, v...)
+	return Fprintln(Stderr, WarnColor, v...)
 }
 
 func Warnf(format string, v ...any) (int, error) {
 	HadWarnings = true
-	return Flogf(Stderr, WarnColor, format, v...)
+	return outputf(Stderr, WarnColor, format, v...)
 }
 
 func Error(v ...any) (int, error) {
-	return Flog(Stderr, ErrorColor, v...)
+	return Fprintln(Stderr, ErrorColor, v...)
 }
 
 func Errorf(format string, v ...any) (int, error) {
-	return Flogf(Stderr, ErrorColor, format, v...)
+	return outputf(Stderr, ErrorColor, format, v...)
 }
 
 func Fatal(msg any) {


### PR DESCRIPTION
I think the colorizer.go was getting out of hand. Lots of mixed use of `term.Print(term.Nop, …)` vs `fmt.Print(…)`, so I deleted `term.Nop` and we just use the `fmt` ones for regular prints.

Also simplified the `Flog` function, because it always did a `fmt.Sprintln` which always adds a newline, so the addNewLine=true had no effect. This meant that only `Flogf` used the logic to add a newline. Furthermore, the `log` package adds newline for empty lines, so I copied that behavior.