### PR TITLE
update sample docs to use defang config rather than defang secrets

### DIFF
--- a/samples/golang/AWS S3/README.md
+++ b/samples/golang/AWS S3/README.md
@@ -1,11 +1,11 @@
 
 ## Setup
-This sample requires an API key to access AWS S3. The name of the secret is referenced in the docker-compose.yml file.
+This sample requires an API key to access AWS S3. The name of the config value is referenced in the docker-compose.yml file.
 To provide a value for it, you can use the Defang CLI like this:
 
 ```
-defang secrets set --name AWS_ACCESS_KEY
-defang secrets set --name AWS_SECRET_KEY
+defang config set --name AWS_ACCESS_KEY
+defang config set --name AWS_SECRET_KEY
 ```
 
 and then enter the value when prompted.

--- a/samples/golang/ChatGPT API/README.md
+++ b/samples/golang/ChatGPT API/README.md
@@ -1,10 +1,10 @@
 
 ## Setup
-This sample requires an API key to access the OpenAI API. The name of the secret is referenced in the docker-compose.yml file.
+This sample requires an API key to access the OpenAI API. The name of the config value is referenced in the docker-compose.yml file.
 To provide a value for it, you can use the Defang CLI like this:
 
 ```
-defang secrets set --name OPENAI_KEY
+defang config set --name OPENAI_KEY
 ```
 
 and then enter the value when prompted.

--- a/samples/golang/slackbot/README.md
+++ b/samples/golang/slackbot/README.md
@@ -18,16 +18,16 @@ Make sure to:
 
 ## Configure
 
-Before deploying the Slackbot, you need to set up some secrets. These secrets are environment variables that the Slackbot needs to function correctly. The secrets are:
+Before deploying the Slackbot, you need to set up some configs parameters. These config parameters are environment variables that the Slackbot needs to function correctly. The parameters are:
 
 - `SLACK_TOKEN`: This is the token you copied previously for the Slack API.
 - `SLACK_CHANNEL_ID`: This is the ID of the Slack channel where the bot will post messages.
 
-You can set these secrets using the `defang secret set` command. Here's how:
+You can set these config parameters using the `defang config set` command. Here's how:
 
 ```sh
-defang secret set --name SLACK_TOKEN --value your_slack_token
-defang secret set --name SLACK_CHANNEL_ID --value your_slack_channel_id
+defang config set --name SLACK_TOKEN --value your_slack_token
+defang config set --name SLACK_CHANNEL_ID --value your_slack_channel_id
 ```
 
 ## Deploy

--- a/samples/golang/slackbot/README.md
+++ b/samples/golang/slackbot/README.md
@@ -18,7 +18,7 @@ Make sure to:
 
 ## Configure
 
-Before deploying the Slackbot, you need to set up some configs parameters. These config parameters are environment variables that the Slackbot needs to function correctly. The parameters are:
+Before deploying the Slackbot, you need to set up some config values. These config values are environment variables that the Slackbot needs to function correctly. The values are:
 
 - `SLACK_TOKEN`: This is the token you copied previously for the Slack API.
 - `SLACK_CHANNEL_ID`: This is the ID of the Slack channel where the bot will post messages.

--- a/samples/nodejs/AWS S3/README.md
+++ b/samples/nodejs/AWS S3/README.md
@@ -1,11 +1,11 @@
 
 ## Setup
-This sample requires an API key to access AWS S3. The name of the secret is referenced in the docker-compose.yml file.
+This sample requires an API key to access AWS S3. The name of the config value is referenced in the docker-compose.yml file.
 To provide a value for it, you can use the Defang CLI like this:
 
 ```
-defang secrets set --name AWS_ACCESS_KEY
-defang secrets set --name AWS_SECRET_KEY
+defang config set --name AWS_ACCESS_KEY
+defang config set --name AWS_SECRET_KEY
 ```
 
 and then enter the value when prompted.

--- a/samples/nodejs/ChatGPT API/README.md
+++ b/samples/nodejs/ChatGPT API/README.md
@@ -1,10 +1,10 @@
 
 ## Setup
-This sample requires an API key to access the OpenAI API. The name of the secret is referenced in the docker-compose.yml file.
+This sample requires an API key to access the OpenAI API. The name of the config value is referenced in the docker-compose.yml file.
 To provide a value for it, you can use the Defang CLI like this:
-
 ```
-defang secrets set --name OPENAI_KEY
+
+defang config set --name OPENAI_KEY
 ```
 
 and then enter the value when prompted.

--- a/samples/other/vllm/README.md
+++ b/samples/other/vllm/README.md
@@ -11,10 +11,10 @@ This guide demonstrates how to deploy Mistral using VLM. You'll need a Hugging F
 
 1. **Set the Hugging Face Token**
 
-   First, set the Hugging Face token using the `defang secrets` command.
+   First, set the Hugging Face token using the `defang config` command.
 
    ```bash
-   defang secrets set --name HF_TOKEN
+   defang config set --name HF_TOKEN
    ```
 
 2. **Launch with Defang Compose**

--- a/samples/python/AWS S3/README.md
+++ b/samples/python/AWS S3/README.md
@@ -1,11 +1,11 @@
 
 ## Setup
-This sample requires an API key to access AWS S3. The name of the secret is referenced in the docker-compose.yml file.
+This sample requires an API key to access AWS S3. The name of the config values is referenced in the docker-compose.yml file.
 To provide a value for it, you can use the Defang CLI like this:
 
 ```
-defang secrets set --name AWS_ACCESS_KEY
-defang secrets set --name AWS_SECRET_KEY
+defang config set --name AWS_ACCESS_KEY
+defang config set --name AWS_SECRET_KEY
 ```
 
 and then enter the value when prompted.

--- a/samples/python/ChatGPT API/README.md
+++ b/samples/python/ChatGPT API/README.md
@@ -1,10 +1,9 @@
 
 ## Setup
-This sample requires an API key to access the OpenAI API. The name of the secret is referenced in the docker-compose.yml file.
-To provide a value for it, you can use the Defang CLI like this:
+This sample requires an API key to access the OpenAI API. The name of the config value is referenced in the docker-compose.yml file. To provide a value for it, you can use the Defang CLI like this:
 
 ```
-defang secrets set --name OPENAI_KEY
+defang config set --name OPENAI_KEY
 ```
 
 and then enter the value when prompted.


### PR DESCRIPTION
Wait on https://github.com/defang-io/defang/pull/328 to be merged first.
Secrets are being renames config.