### PR TITLE
show errors on cli run but allow install.js to pass. 

### DIFF
--- a/pkgs/npm/package.json
+++ b/pkgs/npm/package.json
@@ -23,14 +23,12 @@
   "dependencies": {
     "adm-zip": "^0.5.12",
     "axios": "^1.6.8",
-    "graceful-fs": "^4.2.11",
     "https": "^1.0.0",
     "os": "^0.1.2",
     "tar": "^7.0.1"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.5",
-    "@types/graceful-fs": "^4.1.9",
     "@types/node": "^20.12.7",
     "@types/tar": "^6.1.13",
     "typescript": "^5.4.5"

--- a/pkgs/npm/src/cli.ts
+++ b/pkgs/npm/src/cli.ts
@@ -24,11 +24,15 @@ function getPathToExecutable(): string {
 // in the user PATH to the cli.js to execute. The symlink will name the same as
 // the package name i.e. defang.
 function run(): void {
-  const args = process.argv.slice(2);
-  const processResult = child_process.spawnSync(getPathToExecutable(), args, {
-    stdio: "inherit",
-  });
-  process.exit(processResult.status ?? 0);
+  try {
+    const args = process.argv.slice(2);
+    const processResult = child_process.spawnSync(getPathToExecutable(), args, {
+      stdio: "inherit",
+    });
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
 }
 
 run();

--- a/pkgs/npm/src/cli.ts
+++ b/pkgs/npm/src/cli.ts
@@ -34,7 +34,7 @@ function run(): void {
     process.exitCode = processResult.status ?? 1;
   } catch (error) {
     console.error(error);
-    process.exitCode = 1;
+    process.exitCode = 2;
   }
 }
 

--- a/pkgs/npm/src/cli.ts
+++ b/pkgs/npm/src/cli.ts
@@ -24,14 +24,15 @@ function getPathToExecutable(): string {
 // in the user PATH to the cli.js to execute. The symlink will name the same as
 // the package name i.e. defang.
 function run(): void {
+  let processResult: child_process.SpawnSyncReturns<Buffer> | null = null;
   try {
     const args = process.argv.slice(2);
-    const processResult = child_process.spawnSync(getPathToExecutable(), args, {
+    processResult = child_process.spawnSync(getPathToExecutable(), args, {
       stdio: "inherit",
     });
   } catch (error) {
     console.error(error);
-    process.exit(1);
+    process.exitCode = processResult?.status ?? 1;
   }
 }
 

--- a/pkgs/npm/src/cli.ts
+++ b/pkgs/npm/src/cli.ts
@@ -24,15 +24,17 @@ function getPathToExecutable(): string {
 // in the user PATH to the cli.js to execute. The symlink will name the same as
 // the package name i.e. defang.
 function run(): void {
-  let processResult: child_process.SpawnSyncReturns<Buffer> | null = null;
   try {
     const args = process.argv.slice(2);
-    processResult = child_process.spawnSync(getPathToExecutable(), args, {
+    const processResult = child_process.spawnSync(getPathToExecutable(), args, {
       stdio: "inherit",
     });
+
+    processResult.error && console.error(processResult.error);
+    process.exitCode = processResult.status ?? 1;
   } catch (error) {
     console.error(error);
-    process.exitCode = processResult?.status ?? 1;
+    process.exitCode = 1;
   }
 }
 

--- a/pkgs/npm/src/installer.ts
+++ b/pkgs/npm/src/installer.ts
@@ -41,7 +41,7 @@ async function downloadFile(
     fs.writeFileSync(downloadTargetFile, response.data);
     return downloadTargetFile;
   } catch (error) {
-    console.error(`Failed to download ${downloadUrl}. ${error}`);
+    console.error(error);
     fs.unlinkSync(downloadTargetFile);
     return "";
   }
@@ -165,7 +165,6 @@ async function install() {
     deleteArchive(archiveFile);
   } catch (error) {
     console.error(error);
-    process.exit(1);
   }
 }
 


### PR DESCRIPTION
npx swallows postInstall errors so users do not see errors and the cli doesn't execute the defang command.
There's no way (I've found) to cause npx to show error on postInstall so will allow postInstall to pass even if it failed to download. Cli will be run after, it will throw an error there which will be visible from npx.

Fixes #339 