### PR TITLE
fix for missing project names

### DIFF
--- a/src/pkg/cli/bootstrap.go
+++ b/src/pkg/cli/bootstrap.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/defang-io/defang/src/pkg/cli/client"
@@ -9,7 +10,12 @@ import (
 )
 
 func BootstrapCommand(ctx context.Context, client client.Client, command string) error {
-	term.Debug(" - Running CD command", command)
+	projectName, err := client.LoadProjectName()
+	if err != nil {
+		return err
+	}
+
+	term.Debug(" - Running CD command", command, "in project", projectName)
 	if DoDryRun {
 		return ErrDryRun
 	}
@@ -26,5 +32,12 @@ func BootstrapList(ctx context.Context, client client.Client) error {
 	if DoDryRun {
 		return ErrDryRun
 	}
-	return client.BootstrapList(ctx)
+	stacks, err := client.BootstrapList(ctx)
+	if err != nil {
+		return err
+	}
+	for _, stack := range stacks {
+		fmt.Println(" -", stack)
+	}
+	return nil
 }

--- a/src/pkg/cli/cert.go
+++ b/src/pkg/cli/cert.go
@@ -18,6 +18,13 @@ var resolver = net.Resolver{}
 var httpClient = http.Client{}
 
 func GenerateLetsEncryptCert(ctx context.Context, client cliClient.Client) error {
+	projectName, err := client.LoadProjectName()
+	if err != nil {
+		return err
+	}
+
+	term.Debug(" - Generating Let's Encrypt cert for project", projectName)
+
 	services, err := client.GetServices(ctx)
 	if err != nil {
 		return err

--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -350,6 +350,9 @@ func (b *ByocAws) bucketName() string {
 }
 
 func (b *ByocAws) environment() map[string]string {
+	if b.pulumiProject == "" {
+		panic("pulumiProject not set")
+	}
 	region := b.driver.Region // TODO: this should be the destination region, not the CD region; make customizable
 	return map[string]string{
 		// "AWS_REGION":               region.String(), should be set by ECS (because of CD task role)

--- a/src/pkg/cli/client/byoc/aws/byoc.go
+++ b/src/pkg/cli/client/byoc/aws/byoc.go
@@ -84,11 +84,10 @@ func (b *ByocAws) LoadProject() (*compose.Project, error) {
 	}
 	var proj *compose.Project
 	var err error
-	loader := b.GrpcClient.Loader
 	if b.pulumiProject != "" {
-		proj, err = loader.LoadWithProjectName(b.pulumiProject)
+		proj, err = b.GrpcClient.Loader.LoadWithProjectName(b.pulumiProject)
 	} else {
-		proj, err = loader.LoadWithDefaultProjectName(b.tenantID)
+		proj, err = b.GrpcClient.Loader.LoadWithDefaultProjectName(b.tenantID)
 	}
 	if err != nil {
 		return nil, err

--- a/src/pkg/cli/client/client.go
+++ b/src/pkg/cli/client/client.go
@@ -54,7 +54,7 @@ type Client interface {
 	WhoAmI(context.Context) (*defangv1.WhoAmIResponse, error)
 
 	LoadProject() (*compose.Project, error)
-	LoadProjectName() (string, error)
+	LoadProjectName() (string, error) // TODO: should probably be a private method
 }
 
 type Property struct {

--- a/src/pkg/cli/client/client.go
+++ b/src/pkg/cli/client/client.go
@@ -54,6 +54,7 @@ type Client interface {
 	WhoAmI(context.Context) (*defangv1.WhoAmIResponse, error)
 
 	LoadProject() (*compose.Project, error)
+	LoadProjectName() (string, error)
 }
 
 type Property struct {

--- a/src/pkg/cli/client/client.go
+++ b/src/pkg/cli/client/client.go
@@ -26,7 +26,7 @@ type Client interface {
 	// Update(context.Context, *v1.Service) (*v1.ServiceInfo, error)
 	AgreeToS(context.Context) error
 	BootstrapCommand(context.Context, string) (types.ETag, error)
-	BootstrapList(context.Context) error
+	BootstrapList(context.Context) ([]string, error)
 	CheckLoginAndToS(context.Context) error
 	CreateUploadURL(context.Context, *defangv1.UploadURLRequest) (*defangv1.UploadURLResponse, error)
 	DelegateSubdomainZone(context.Context, *defangv1.DelegateSubdomainZoneRequest) (*defangv1.DelegateSubdomainZoneResponse, error)

--- a/src/pkg/cli/client/grpc.go
+++ b/src/pkg/cli/client/grpc.go
@@ -63,7 +63,8 @@ func getMsg[T any](resp *connect.Response[T], err error) (*T, error) {
 }
 
 func (g GrpcClient) LoadProject() (*compose.Project, error) {
-	return g.Loader.LoadWithDefaultProjectName(string(g.tenantID))
+	projectName, _ := g.LoadProjectName()
+	return g.Loader.LoadWithDefaultProjectName(projectName)
 }
 
 func (g GrpcClient) GetVersions(ctx context.Context) (*defangv1.Version, error) {
@@ -241,4 +242,8 @@ func (g *GrpcClient) Restart(ctx context.Context, names ...string) (types.ETag, 
 func (g GrpcClient) ServiceDNS(name string) string {
 	whoami, _ := g.WhoAmI(context.TODO())
 	return whoami.Tenant + "-" + name
+}
+
+func (g GrpcClient) LoadProjectName() (string, error) {
+	return string(g.tenantID), nil
 }

--- a/src/pkg/cli/client/grpc.go
+++ b/src/pkg/cli/client/grpc.go
@@ -217,8 +217,8 @@ func (g *GrpcClient) TearDown(ctx context.Context) error {
 	return errors.New("the teardown command is not valid for the Defang provider")
 }
 
-func (g *GrpcClient) BootstrapList(context.Context) error {
-	return errors.New("the list command is not valid for the Defang provider")
+func (g *GrpcClient) BootstrapList(context.Context) ([]string, error) {
+	return nil, errors.New("this command is not valid for the Defang provider")
 }
 
 func (g *GrpcClient) Restart(ctx context.Context, names ...string) (types.ETag, error) {

--- a/src/pkg/cli/composeDown.go
+++ b/src/pkg/cli/composeDown.go
@@ -4,9 +4,15 @@ import (
 	"context"
 
 	"github.com/defang-io/defang/src/pkg/cli/client"
+	"github.com/defang-io/defang/src/pkg/term"
 	"github.com/defang-io/defang/src/pkg/types"
 )
 
 func ComposeDown(ctx context.Context, client client.Client) (types.ETag, error) {
+	projectName, err := client.LoadProjectName()
+	if err != nil {
+		return "", err
+	}
+	term.Debug(" - Destroying project", projectName)
 	return client.Destroy(ctx)
 }

--- a/src/pkg/cli/configDelete.go
+++ b/src/pkg/cli/configDelete.go
@@ -9,7 +9,11 @@ import (
 )
 
 func ConfigDelete(ctx context.Context, client client.Client, names ...string) error {
-	term.Debug(" - Deleting config", names)
+	projectName, err := client.LoadProjectName()
+	if err != nil {
+		return err
+	}
+	term.Debug(" - Deleting config", names, "in project", projectName)
 
 	if DoDryRun {
 		return ErrDryRun

--- a/src/pkg/cli/configList.go
+++ b/src/pkg/cli/configList.go
@@ -4,9 +4,16 @@ import (
 	"context"
 
 	"github.com/defang-io/defang/src/pkg/cli/client"
+	"github.com/defang-io/defang/src/pkg/term"
 )
 
 func ConfigList(ctx context.Context, client client.Client) error {
+	projectName, err := client.LoadProjectName()
+	if err != nil {
+		return err
+	}
+	term.Debug(" - Listing config in project", projectName)
+
 	config, err := client.ListConfig(ctx)
 	if err != nil {
 		return err

--- a/src/pkg/cli/configSet.go
+++ b/src/pkg/cli/configSet.go
@@ -9,12 +9,15 @@ import (
 )
 
 func ConfigSet(ctx context.Context, client client.Client, name string, value string) error {
-	term.Debug(" - Setting config", name)
+	projectName, err := client.LoadProjectName()
+	if err != nil {
+		return err
+	}
+	term.Debug(" - Setting config", name, "in project", projectName)
 
 	if DoDryRun {
 		return ErrDryRun
 	}
 
-	err := client.PutConfig(ctx, &defangv1.SecretValue{Name: name, Value: value})
-	return err
+	return client.PutConfig(ctx, &defangv1.SecretValue{Name: name, Value: value})
 }

--- a/src/pkg/cli/getServices.go
+++ b/src/pkg/cli/getServices.go
@@ -4,10 +4,17 @@ import (
 	"context"
 
 	"github.com/defang-io/defang/src/pkg/cli/client"
+	"github.com/defang-io/defang/src/pkg/term"
 	defangv1 "github.com/defang-io/defang/src/protos/io/defang/v1"
 )
 
 func GetServices(ctx context.Context, client client.Client, long bool) error {
+	projectName, err := client.LoadProjectName()
+	if err != nil {
+		return err
+	}
+	term.Debug(" - Listing services in project", projectName)
+
 	serviceList, err := client.GetServices(ctx)
 	if err != nil {
 		return err

--- a/src/pkg/cli/tail.go
+++ b/src/pkg/cli/tail.go
@@ -100,6 +100,12 @@ func Tail(ctx context.Context, client client.Client, service, etag string, since
 		}
 	}
 
+	projectName, err := client.LoadProjectName()
+	if err != nil {
+		return err
+	}
+	term.Debug(" - Tailing logs in project", projectName)
+
 	if DoDryRun {
 		return ErrDryRun
 	}


### PR DESCRIPTION
Some commands need the project name to be available (for example SSM resource name or bucket names), but don't need the whole project loaded.

Fixes #348 