### PR TITLE
fix version check to handle dev builds

### DIFF
--- a/src/cmd/cli/command/version.go
+++ b/src/cmd/cli/command/version.go
@@ -5,17 +5,35 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"golang.org/x/mod/semver"
 )
 
 var httpClient = http.DefaultClient
 
-func GetCurrentVersion() string {
-	version := RootCmd.Version
-	if v := semver.Canonical("v" + version); v != "" {
-		return v
+func isNewer(current, comparand string) bool {
+	version, ok := normalizeVersion(current)
+	if !ok {
+		return false // development versions are always considered "latest"
 	}
+	return semver.Compare(version, comparand) < 0
+}
+
+func isGitRef(maybeVersion string) bool {
+	return len(maybeVersion) >= 7 && !strings.Contains(maybeVersion, ".")
+}
+
+func normalizeVersion(maybeVersion string) (string, bool) {
+	version := "v" + maybeVersion
+	if semver.IsValid(version) && !isGitRef(maybeVersion) {
+		return version, true
+	}
+	return maybeVersion, false // leave as is
+}
+
+func GetCurrentVersion() string {
+	version, _ := normalizeVersion(RootCmd.Version)
 	return version
 }
 
@@ -39,5 +57,5 @@ func GetLatestVersion(ctx context.Context) (string, error) {
 	if err = json.NewDecoder(resp.Body).Decode(&release); err != nil {
 		return "", err
 	}
-	return semver.Canonical(release.TagName), nil
+	return release.TagName, nil
 }

--- a/src/cmd/cli/command/version_test.go
+++ b/src/cmd/cli/command/version_test.go
@@ -8,6 +8,29 @@ import (
 	"testing"
 )
 
+func TestIsNewer(t *testing.T) {
+	tests := []struct {
+		cli    string
+		latest string
+		want   bool
+	}{
+		{"1.0.0", "v1.0.0", false},
+		{"1.0.0", "v1.0.1", true},
+		{"1.0.1", "v1.0.0", false},
+		{"1.0.0", "v1.1.0", true},
+		{"development", "v1.0.0", false},
+		{"1234abc", "v1.0.0", false},
+		{"1234567", "v1.0.0", false},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%v<>%v", tt.cli, tt.latest), func(t *testing.T) {
+			if got := isNewer(tt.cli, tt.latest); got != tt.want {
+				t.Errorf("IsNewer() = %v; want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetCurrentVersion(t *testing.T) {
 	RootCmd.Version = "development"
 	dev := GetCurrentVersion()
@@ -19,6 +42,12 @@ func TestGetCurrentVersion(t *testing.T) {
 	v := GetCurrentVersion()
 	if v != "v1.0.0" {
 		t.Errorf("GetCurrentVersion() = %v; want v1.0.0", v)
+	}
+
+	RootCmd.Version = "1234567" // GIT ref
+	ref := GetCurrentVersion()
+	if ref != "1234567" {
+		t.Errorf("GetCurrentVersion() = %v; want 1234567", ref)
 	}
 }
 


### PR DESCRIPTION
dev builds should be considered latest version and not trigger the "update" or "outdated" warnings.